### PR TITLE
docs: rewrite bilingual README and add MIT license

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -67,6 +67,7 @@
         "name": "Oscaner Miao",
         "email": "oscaner1997@gmail.com"
       },
+      "license": "MIT",
       "version": "6.2.0-overrides.11",
       "category": "workflow",
       "tags": [

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Oscaner Miao
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,30 @@
 # oscaner
 
+[English](README.md) | [简体中文](README.zh-CN.md)
+
 [![CI](https://github.com/Oscaner/skills/actions/workflows/ci.yml/badge.svg)](https://github.com/Oscaner/skills/actions/workflows/ci.yml)
 
-Personal [Claude Code](https://claude.com/claude-code) plugin marketplace. Packages skills as installable plugins — Markdown + JSON manifests, plus pnpm/changesets for `superpowers-overrides` releases and CI validation.
+*Combine superpowers' full workflow with mattpocock's precision — engineered via superpowers-overrides.*
+
+Personal [Claude Code](https://claude.com/claude-code) plugin marketplace. Three plugins work together as one pipeline: brainstorm, plan, build, ship.
+
+## Why this exists
+
+**[Superpowers](https://github.com/obra/superpowers)** is the full stack — brainstorming, writing plans, subagent-driven development, verification, branch finish. One library, end to end.
+
+**[mattpocock-skills](plugins/mattpocock-skills/)** is the precision layer — `grilling` for hard questions, `tdd` for implementation, `to-tickets` for slicing work. Small surface, sharp tools.
+
+Neither alone told me *when* to delegate, *how* to review specs, or *how to phase* a large feature. **superpowers-overrides** sits in front of upstream superpowers skills: intercept, replace or delegate, and wire mattpocock in at the right step. For big scope it adds **overall + phase** — decompose in an overall spec, then run full spec → plan → dev cycles one phase at a time.
+
+## The pipeline
+
+```
+Overall spec → Phase spec → Plan → SDD/TDD → Verify → Ship
+```
+
+Overrides add grilling and subagent review at design time; mattpocock handles grilling, tdd, and to-tickets via delegation.
+
+Skill mapping and harness setup → [superpowers-overrides README](plugins/superpowers-overrides/README.md).
 
 ## Installation
 
@@ -14,7 +36,7 @@ Personal [Claude Code](https://claude.com/claude-code) plugin marketplace. Packa
 /plugin install superpowers-overrides@oscaner
 ```
 
-Cloning this repo requires initializing the `mattpocock-skills` submodule:
+Clone this repo (submodule required for local development):
 
 ```bash
 git clone https://github.com/Oscaner/skills.git
@@ -22,84 +44,24 @@ cd skills
 git submodule update --init
 ```
 
-Bump submodule later: `git submodule update --remote mattpocock-skills` and commit with `chore:`.
-
-## Plugins
-
-### [mattpocock-skills](plugins/mattpocock-skills/)
-
-Vendored submodule tracking [`mattpocock/skills`](https://github.com/mattpocock/skills). Re-exported so overrides can delegate to `mattpocock-skills:grilling`, `tdd`, `to-tickets`.
-
-### [superpowers-overrides](plugins/superpowers-overrides/)
-
-Personal overrides for upstream [`superpowers`](https://github.com/obra/superpowers). Each `spor-*` skill intercepts a matching `superpowers:*` skill and runs **first** — replacing or delegating behavior. See [CLAUDE.md](CLAUDE.md) for the full override table and contributor pattern.
-
 ## Quick start
 
-1. Install `superpowers` + `superpowers-overrides` from the marketplace (see [Installation](#installation)).
-2. Run **`/spor-init`** once per project (Claude Code: `/superpowers-overrides:spor-init`) — writes override self-check rules to the project.
-3. Use upstream commands as normal — overrides fire automatically:
-   - Claude Code: `/superpowers:brainstorming`, `/superpowers:writing-plans`, …
-   - Cursor: `/spor-brainstorming`, `/spor-writing-plans`, …
+1. Install `superpowers`, `superpowers-overrides`, and `mattpocock-skills` from the marketplace.
+2. Run the **init skill** once per project — re-run after plugin upgrades. Slash command depends on your harness → [Usage](plugins/superpowers-overrides/README.md#usage).
+3. Invoke the superpowers workflow as you normally would — overrides intercept and run first.
 
-**Cursor:** Team Marketplace import + discovery fallback — [cross-harness-overrides.md](plugins/superpowers-overrides/docs/cross-harness-overrides.md). Smoke checklist: [CURSOR-SMOKE.md](plugins/superpowers-overrides/docs/CURSOR-SMOKE.md).
+## Learn more
 
-## Common override skills
-
-| Skill | Overrides | Notes |
-|---|---|---|
-| `spor-init` | — | Project wiring via `/spor-init` |
-| `spor-brainstorming` | `superpowers:brainstorming` | Grilling + subagent spec review |
-| `spor-writing-plans` | `superpowers:writing-plans` | Section writes + local tickets |
-| `spor-subagent-driven-development` | `superpowers:subagent-driven-development` | Complexity-based review rounds |
-
-Full list: [CLAUDE.md](CLAUDE.md) and [cross-harness-overrides.md](plugins/superpowers-overrides/docs/cross-harness-overrides.md).
-
-## Repository layout
-
-```
-marketplace/source.json              # canonical registry (human-edited)
-.claude-plugin/marketplace.json    # generated — Claude Code
-.cursor-plugin/marketplace.json    # generated — Cursor Team Marketplace
-cursor-plugins/                    # generated Cursor wrappers
-plugins/<plugin>/                  # plugin trees
-```
-
-Edit [marketplace/source.json](marketplace/source.json), then `pnpm run emit && pnpm run validate`.
-
-## Enforcement
-
-Overrides are enforced by three layers: each skill's four-trigger `description`, a `UserPromptExpansion` hook on `/superpowers:*` slash commands, and project rules written by **`/spor-init`** (`.cursor/rules/superpowers-overrides.mdc` in Cursor; `CLAUDE.md` self-check in Claude Code). Re-run init after plugin upgrades to refresh version stamps.
-
-Harness details: [cross-harness-overrides.md](plugins/superpowers-overrides/docs/cross-harness-overrides.md).
+[superpowers-overrides README](plugins/superpowers-overrides/README.md) — skills by phase, Claude Code vs Cursor, enforcement layers.
 
 ## Maintainers
 
-After editing override skills, manifest, or generators:
+After editing overrides: `pnpm run generate:overrides && pnpm run emit && pnpm run validate`.
 
-```bash
-pnpm run generate:overrides
-pnpm run emit
-pnpm run validate
-```
-
-Release workflow: [.changeset/README.md](.changeset/README.md).
-
-## Releasing
-
-Only `superpowers-overrides` is versioned. Tags: `superpowers-overrides@{superpowers-version}-overrides.{N}`.
-
-| Change | What to do |
-|--------|------------|
-| Overrides skill / manifest / build | `pnpm changeset` → PR → merge Version PR → tag |
-| Superpowers submodule bump | Update pointer + `marketplace/source.json` → `pnpm run emit` → PR |
-
-Changelog: [plugins/superpowers-overrides/CHANGELOG.md](plugins/superpowers-overrides/CHANGELOG.md).
-
-## Contributing
-
-New override rules go inside the override skill as `Rule N`. New override skills follow the pattern in [CLAUDE.md#the-overrides-pattern-superpowers-overrides](CLAUDE.md#the-overrides-pattern-superpowers-overrides).
+Release: [`.changeset/README.md`](.changeset/README.md). Contributor pattern: [`CLAUDE.md`](CLAUDE.md).
 
 ## License
 
-Personal use. No warranty. Adapt freely for your own setup.
+First-party code (`superpowers-overrides`, marketplace tooling) is [MIT](LICENSE).
+
+Vendored plugins keep their own licenses — see each plugin directory (e.g. `plugins/mattpocock-skills/LICENSE`).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,67 @@
+# oscaner
+
+[English](README.md) | [简体中文](README.zh-CN.md)
+
+[![CI](https://github.com/Oscaner/skills/actions/workflows/ci.yml/badge.svg)](https://github.com/Oscaner/skills/actions/workflows/ci.yml)
+
+*用 superpowers-overrides 把 superpowers 的全流程和 mattpocock 的精专缝成一条工程化流水线。*
+
+个人 [Claude Code](https://claude.com/claude-code) 插件市场。三个插件组成一条流水线：构思 → 计划 → 开发 → 交付。
+
+## 为什么有这个市场
+
+**[Superpowers](https://github.com/obra/superpowers)** 大而全——从 brainstorming、写计划、子 agent 驱动开发，到验证、收尾分支，一套走完。
+
+**[mattpocock-skills](plugins/mattpocock-skills/)** 小而精——`grilling` 挖清需求，`tdd` 管实现，`to-tickets` 切任务。每个 skill 只做一件事，但做得很准。
+
+单独用哪一个，都缺一块：什么时候 delegate、spec 怎么审、大功能怎么分期。**superpowers-overrides** 拦在上游 superpowers skill 前面——该替换的替换，该委托的委托，并在关键步骤接上 mattpocock。大需求走 **overall + phase**：先写 overall spec 分解范围，再逐 phase 跑完整的 spec → plan → dev 循环。
+
+## 流水线
+
+```
+Overall spec → Phase spec → Plan → SDD/TDD → Verify → Ship
+```
+
+overrides 在设计阶段加入 grilling 和 subagent review；grilling、tdd、to-tickets 通过 delegate 交给 mattpocock。
+
+各阶段对应哪些 override → [superpowers-overrides 说明](plugins/superpowers-overrides/README.zh-CN.md)。
+
+## 安装
+
+```bash
+# In Claude Code
+/plugin marketplace add oscaner/skills
+/plugin install mattpocock-skills@oscaner
+/plugin install superpowers@oscaner
+/plugin install superpowers-overrides@oscaner
+```
+
+克隆本仓库（本地开发需初始化 submodule）：
+
+```bash
+git clone https://github.com/Oscaner/skills.git
+cd skills
+git submodule update --init
+```
+
+## 快速开始
+
+1. 从 marketplace 安装 `superpowers`、`superpowers-overrides`、`mattpocock-skills`。
+2. 每个项目跑一次 **init skill**——插件升级后重跑。具体 slash 命令因 harness 而异 → [用法](plugins/superpowers-overrides/README.zh-CN.md#用法)。
+3. 照常调用 superpowers 工作流——overrides 会自动先执行。
+
+## 延伸阅读
+
+[superpowers-overrides 说明](plugins/superpowers-overrides/README.zh-CN.md)——按阶段的 skills、Claude Code / Cursor 差异、三层 enforcement。
+
+## 维护者
+
+修改 overrides 后：`pnpm run generate:overrides && pnpm run emit && pnpm run validate`。
+
+发布流程：[`.changeset/README.md`](.changeset/README.md)。贡献模式：[`CLAUDE.md`](CLAUDE.md)。
+
+## 许可
+
+本仓库 first-party 代码（`superpowers-overrides`、marketplace 工具链）采用 [MIT](LICENSE)。
+
+Vendored 插件保留各自许可——见各插件目录（如 `plugins/mattpocock-skills/LICENSE`）。

--- a/cursor-plugins/superpowers-overrides/.cursor-plugin/plugin.json
+++ b/cursor-plugins/superpowers-overrides/.cursor-plugin/plugin.json
@@ -8,5 +8,6 @@
     "email": "oscaner1997@gmail.com"
   },
   "skills": "../../plugins/superpowers-overrides/skills",
-  "version": "6.2.0-overrides.11"
+  "version": "6.2.0-overrides.11",
+  "license": "MIT"
 }

--- a/marketplace/source.json
+++ b/marketplace/source.json
@@ -83,6 +83,7 @@
         "name": "Oscaner Miao",
         "email": "oscaner1997@gmail.com"
       },
+      "license": "MIT",
       "contentRoot": "plugins/superpowers-overrides",
       "claude": {
         "category": "workflow",

--- a/plugins/superpowers-overrides/LICENSE
+++ b/plugins/superpowers-overrides/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Oscaner Miao
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/superpowers-overrides/README.md
+++ b/plugins/superpowers-overrides/README.md
@@ -1,0 +1,92 @@
+# superpowers-overrides
+
+[English](README.md) | [简体中文](README.zh-CN.md)
+
+Personal overrides for [superpowers](https://github.com/obra/superpowers). Each `spor-*` skill runs **before** its upstream target — replacing behavior or delegating to [mattpocock-skills](../mattpocock-skills/).
+
+## What overrides do
+
+When you invoke `/brainstorming`, `/writing-plans`, or any other superpowers skill, the matching `spor-*` override loads first. It either **replaces** upstream steps (e.g. self-review → fresh subagent passes) or **delegates** to mattpocock skills (e.g. clarifying questions → `grilling`, implementation → `tdd`).
+
+Three layers keep overrides from being skipped:
+
+1. **Skill description** — four-trigger frontmatter; override must be the first tool call.
+2. **Hook** — `UserPromptExpansion` on `/superpowers:*` slash commands (Claude Code).
+3. **Project rules** — `/spor-init` writes self-check rules into your project (`CLAUDE.md` or `.cursor/rules/superpowers-overrides.mdc`).
+
+## Workflow
+
+Simplified main-path diagram — not a complete skill inventory. Overall/phase, policy, cross-cutting skills, and `spor-receiving-code-review` are in the table below.
+
+```mermaid
+flowchart LR
+  subgraph discover["Discover"]
+    B[spor-brainstorming]
+  end
+  subgraph plan["Plan"]
+    W[spor-writing-plans]
+  end
+  subgraph build["Build"]
+    SDD[spor-subagent-driven-development]
+    EP[spor-executing-plans]
+    TDD[spor-test-driven-development]
+    DBG[spor-systematic-debugging]
+  end
+  subgraph ship["Ship"]
+    V[spor-verification-before-completion]
+    F[spor-finishing-a-development-branch]
+  end
+  B --> W --> SDD --> V --> F
+  EP -.-> SDD
+  TDD -.-> SDD
+  DBG -.-> SDD
+```
+
+**Overall + phase:** large scope → write an overall spec and get decomposition approval → explicit gate → per-phase discover→ship cycle. The main README ASCII pipeline includes Phase spec; this diagram shows the per-phase skill intercept chain from Discover onward.
+
+## Skills by phase
+
+| Phase | Skill | What it does |
+|-------|-------|--------------|
+| Setup | `spor-init` | Project wiring; run once after install |
+| Discover | `spor-brainstorming` | Delegates discovery to `grilling`; subagent spec review; overall/phase for large scope |
+| Plan | `spor-writing-plans` | Section-by-section plan writes + review; tickets to `docs/superpowers/tickets/` |
+| Build | `spor-subagent-driven-development` | Complexity-based review rounds; implementers delegate to `tdd` |
+| Build | `spor-executing-plans` | Plan execution; redirects to SDD when subagents available; per-task commits |
+| Build | `spor-test-driven-development` | Confirms seams with user; delegates loop to mattpocock `tdd` |
+| Build | `spor-systematic-debugging` | Evidence before fixes; delegates to `diagnosing-bugs` |
+| Ship | `spor-verification-before-completion` | No completion claims without verification evidence |
+| Ship | `spor-finishing-a-development-branch` | Branch finish / PR; no worktrees; conventional commits |
+| Ship | `spor-receiving-code-review` | Unclear feedback → `grilling`; fixes → `tdd` (not in diagram — often mid-build or pre-ship) |
+| Policy | `spor-using-git-worktrees` | Refuses worktree creation (user policy) |
+| Cross-cutting | `spor-subagent-lifecycle` | Fresh subagent per pass; concurrency rules (referenced, no slash) |
+| Cross-cutting | `spor-token-efficient-review-dispatch` | D1/D2/D3 review dispatch (referenced, no slash) |
+
+## Usage
+
+### Common
+
+1. Install `superpowers`, `superpowers-overrides`, and `mattpocock-skills` from the oscaner marketplace.
+2. Run **`/spor-init`** in each project (re-run after plugin upgrades).
+3. Invoke upstream superpowers skills — overrides intercept automatically.
+
+### Claude Code
+
+- Workflow: `/superpowers:brainstorming`, `/superpowers:writing-plans`, …
+- Init: `/superpowers-overrides:spor-init` → writes self-check block to project `CLAUDE.md`.
+
+### Cursor
+
+- Workflow: `/spor-brainstorming`, `/spor-writing-plans`, … (or rules-based intercept).
+- Init: `/spor-init` → writes `.cursor/rules/superpowers-overrides.mdc`.
+- See [cross-harness-overrides.md](docs/cross-harness-overrides.md) and [CURSOR-SMOKE.md](docs/CURSOR-SMOKE.md).
+
+## Docs for maintainers
+
+- [cross-harness-overrides.md](docs/cross-harness-overrides.md)
+- [CLAUDE.md](../../CLAUDE.md) — override pattern, contributor guide
+- [CHANGELOG.md](CHANGELOG.md)
+
+## License
+
+[MIT](LICENSE)

--- a/plugins/superpowers-overrides/README.zh-CN.md
+++ b/plugins/superpowers-overrides/README.zh-CN.md
@@ -1,0 +1,92 @@
+# superpowers-overrides
+
+[English](README.md) | [简体中文](README.zh-CN.md)
+
+对 [superpowers](https://github.com/obra/superpowers) 的个人 override。每个 `spor-*` skill 在对应上游 skill **之前**运行——替换行为或 delegate 到 [mattpocock-skills](../mattpocock-skills/)。
+
+## overrides 做什么
+
+调用 `/brainstorming`、`/writing-plans` 等 superpowers skill 时，匹配的 `spor-*` override 会先加载。它要么 **replace** 上游步骤（如 self-review → 全新 subagent 审查），要么 **delegate** 给 mattpocock skill（如澄清问题 → `grilling`，实现 → `tdd`）。
+
+三层机制防止 override 被跳过：
+
+1. **Skill description** — 四触发 frontmatter；override 必须是本 turn 第一个 tool call。
+2. **Hook** — Claude Code 上 `/superpowers:*` 的 `UserPromptExpansion`。
+3. **项目规则** — `/spor-init` 写入项目（`CLAUDE.md` 或 `.cursor/rules/superpowers-overrides.mdc`）。
+
+## 工作流
+
+简化主路径图——不是完整 skill 清单。overall/phase、policy、cross-cutting skills 和 `spor-receiving-code-review` 见下方表格。
+
+```mermaid
+flowchart LR
+  subgraph discover["Discover"]
+    B[spor-brainstorming]
+  end
+  subgraph plan["Plan"]
+    W[spor-writing-plans]
+  end
+  subgraph build["Build"]
+    SDD[spor-subagent-driven-development]
+    EP[spor-executing-plans]
+    TDD[spor-test-driven-development]
+    DBG[spor-systematic-debugging]
+  end
+  subgraph ship["Ship"]
+    V[spor-verification-before-completion]
+    F[spor-finishing-a-development-branch]
+  end
+  B --> W --> SDD --> V --> F
+  EP -.-> SDD
+  TDD -.-> SDD
+  DBG -.-> SDD
+```
+
+**Overall + phase：** 大 scope → 写 overall spec 并获分解批准 → 显式 gate → 每个 phase 独立跑 discover→ship。主 README 的 ASCII 流水线包含 Phase spec；此图展示从 Discover 起的 per-phase skill 拦截链。
+
+## 按阶段划分的 Skills
+
+| 阶段 | Skill | 作用 |
+|------|-------|------|
+| Setup | `spor-init` | 项目 wiring；安装后跑一次 |
+| Discover | `spor-brainstorming` | discovery delegate 给 `grilling`；subagent spec review；大 scope 走 overall/phase |
+| Plan | `spor-writing-plans` | 分段写 plan + review；tickets 发布到 `docs/superpowers/tickets/` |
+| Build | `spor-subagent-driven-development` | 按复杂度多轮 review；implementer delegate 给 `tdd` |
+| Build | `spor-executing-plans` | 执行 plan；有 subagent 时转 SDD；每 task commit |
+| Build | `spor-test-driven-development` | 与用户确认 seam；循环 delegate 给 mattpocock `tdd` |
+| Build | `spor-systematic-debugging` | 先有证据再提 fix；delegate 给 `diagnosing-bugs` |
+| Ship | `spor-verification-before-completion` | 无验证证据不得声称完成 |
+| Ship | `spor-finishing-a-development-branch` | 分支收尾 / PR；禁止 worktree；conventional commits |
+| Ship | `spor-receiving-code-review` | 不清楚的反馈 → `grilling`；fix → `tdd`（不在图中——常在 build 中或 ship 前） |
+| Policy | `spor-using-git-worktrees` | 拒绝创建 worktree（用户策略） |
+| Cross-cutting | `spor-subagent-lifecycle` | 每 pass 全新 subagent；并发规则（被引用，无 slash） |
+| Cross-cutting | `spor-token-efficient-review-dispatch` | D1/D2/D3 review dispatch（被引用，无 slash） |
+
+## 用法
+
+### 通用
+
+1. 从 oscaner marketplace 安装 `superpowers`、`superpowers-overrides`、`mattpocock-skills`。
+2. 每个项目运行 **`/spor-init`**（插件升级后重跑）。
+3. 照常调用 upstream superpowers skill——overrides 自动拦截。
+
+### Claude Code
+
+- 工作流：`/superpowers:brainstorming`、`/superpowers:writing-plans` …
+- Init：`/superpowers-overrides:spor-init` → 写入项目 `CLAUDE.md` self-check 块。
+
+### Cursor
+
+- 工作流：`/spor-brainstorming`、`/spor-writing-plans` …（或 rules 拦截）。
+- Init：`/spor-init` → 写入 `.cursor/rules/superpowers-overrides.mdc`。
+- 详见 [cross-harness-overrides.md](docs/cross-harness-overrides.md) 和 [CURSOR-SMOKE.md](docs/CURSOR-SMOKE.md)。
+
+## 维护者文档
+
+- [cross-harness-overrides.md](docs/cross-harness-overrides.md)
+- [CLAUDE.md](../../CLAUDE.md) — override 模式、贡献指南
+- [CHANGELOG.md](CHANGELOG.md)
+
+## 许可
+
+[MIT](LICENSE)

--- a/plugins/superpowers-overrides/package.json
+++ b/plugins/superpowers-overrides/package.json
@@ -7,5 +7,6 @@
     "type": "git",
     "url": "https://github.com/Oscaner/skills",
     "directory": "plugins/superpowers-overrides"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
Tell the superpowers + mattpocock + overrides story in EN/ZH main READMEs, add dedicated sub-READMEs with workflow and skill reference, and declare MIT for first-party superpowers-overrides in marketplace metadata.