### PR TITLE
fix: emit when mattpocock tag lacks plugin version

### DIFF
--- a/scripts/bump-submodule.mjs
+++ b/scripts/bump-submodule.mjs
@@ -85,6 +85,11 @@ function applyBump(bumpName, result, newTag) {
 
   checkoutTag(newTag);
 
+  if (bumpName === "mattpocock-skills") {
+    execSync("pnpm run emit", { stdio: "inherit", cwd: root });
+    return;
+  }
+
   if (bumpName === "impeccable") {
     const sourcePath = "marketplace/source.json";
     const source = readJson(sourcePath);

--- a/scripts/lib/marketplace-utils.mjs
+++ b/scripts/lib/marketplace-utils.mjs
@@ -1,6 +1,11 @@
 import { readFileSync, existsSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  TAG_PATTERNS,
+  SUBMODULE_PATHS,
+  semverFromNearestTag,
+} from "./submodule-tags.mjs";
 
 const GENERATED = "scripts/emit-marketplace.mjs — do not edit";
 
@@ -40,20 +45,24 @@ export function resolveVersion(root, plugin) {
   const truthVersion = truth.version;
 
   if (plugin.name === "mattpocock-skills") {
-    if (!truthVersion) {
-      if (plugin.version !== undefined) {
-        throw new Error(
-          `Version in source for ${plugin.name} but missing in ${truthPath}`,
-        );
-      }
-      return { version: undefined, includeInClaude: false };
-    }
-    if (plugin.version !== undefined && plugin.version !== truthVersion) {
+    const submodulePath = join(root, SUBMODULE_PATHS["mattpocock-skills"]);
+    const pattern = TAG_PATTERNS["mattpocock-skills"];
+    const effectiveVersion =
+      truthVersion ?? semverFromNearestTag(submodulePath, pattern);
+    if (!effectiveVersion) {
       throw new Error(
-        `Version mismatch for ${plugin.name}: source=${plugin.version} truth=${truthVersion} (${truthPath})`,
+        `No version in ${truthPath} and no v* release tag on submodule HEAD`,
       );
     }
-    return { version: truthVersion, includeInClaude: plugin.version !== undefined };
+    if (plugin.version !== undefined && plugin.version !== effectiveVersion) {
+      throw new Error(
+        `Version mismatch for ${plugin.name}: source=${plugin.version} truth=${effectiveVersion} (${truthPath})`,
+      );
+    }
+    return {
+      version: effectiveVersion,
+      includeInClaude: plugin.version !== undefined,
+    };
   }
 
   if (!truthVersion) {

--- a/scripts/lib/marketplace-utils.mjs
+++ b/scripts/lib/marketplace-utils.mjs
@@ -38,17 +38,26 @@ export function resolveVersion(root, plugin) {
 
   const truth = JSON.parse(readFileSync(truthPath, "utf8"));
   const truthVersion = truth.version;
-  if (!truthVersion) {
-    throw new Error(`No version in truth source: ${truthPath}`);
-  }
 
   if (plugin.name === "mattpocock-skills") {
+    if (!truthVersion) {
+      if (plugin.version !== undefined) {
+        throw new Error(
+          `Version in source for ${plugin.name} but missing in ${truthPath}`,
+        );
+      }
+      return { version: undefined, includeInClaude: false };
+    }
     if (plugin.version !== undefined && plugin.version !== truthVersion) {
       throw new Error(
         `Version mismatch for ${plugin.name}: source=${plugin.version} truth=${truthVersion} (${truthPath})`,
       );
     }
     return { version: truthVersion, includeInClaude: plugin.version !== undefined };
+  }
+
+  if (!truthVersion) {
+    throw new Error(`No version in truth source: ${truthPath}`);
   }
 
   if (plugin.version === undefined) {
@@ -93,8 +102,8 @@ export function cursorWrapperManifest(plugin, resolved) {
     description: plugin.description,
     author: plugin.author,
     skills: plugin.cursor.skills,
-    version: resolved.version,
   };
+  if (resolved.version) manifest.version = resolved.version;
   if (plugin.homepage) manifest.homepage = plugin.homepage;
   if (plugin.repository) manifest.repository = plugin.repository;
   if (plugin.license) manifest.license = plugin.license;

--- a/scripts/lib/submodule-tags.mjs
+++ b/scripts/lib/submodule-tags.mjs
@@ -81,6 +81,13 @@ export function latestTag(submodulePath, pattern) {
 }
 
 /** @param {string} submodulePath @param {RegExp} pattern */
+export function semverFromNearestTag(submodulePath, pattern) {
+  const tag = nearestTag(submodulePath, pattern);
+  if (!tag) return null;
+  return parseSemverFromTag(tag, pattern);
+}
+
+/** @param {string} submodulePath @param {RegExp} pattern */
 export function hasUpdate(submodulePath, pattern) {
   fetchTags(submodulePath);
   const latest = latestTag(submodulePath, pattern);

--- a/scripts/lib/submodule-tags.test.mjs
+++ b/scripts/lib/submodule-tags.test.mjs
@@ -27,3 +27,12 @@ describe("sortTagsBySemver", () => {
     assert.equal(sorted.at(-1), "v6.2.0");
   });
 });
+
+describe("semverFromNearestTag", () => {
+  it("derives semver from tag name", () => {
+    assert.equal(
+      parseSemverFromTag("v1.1.0", TAG_PATTERNS["mattpocock-skills"]),
+      "1.1.0",
+    );
+  });
+});

--- a/scripts/submodule-sync-publish.sh
+++ b/scripts/submodule-sync-publish.sh
@@ -20,7 +20,7 @@ if [[ "$UPDATED" != "true" ]]; then
 fi
 
 git fetch origin main
-git fetch origin "$BRANCH" || true
+git fetch origin "$BRANCH" 2>/dev/null || true
 OPEN_PR=$(gh pr list --search "head:${BRANCH} is:open" --json number,body --jq '.[0] // empty')
 
 if [[ -n "$OPEN_PR" ]] && git show-ref --verify --quiet "refs/remotes/origin/${BRANCH}"; then


### PR DESCRIPTION
Allow mattpocock-skills without version in plugin.json during emit (v1.1.0 tag). Run pnpm emit after mattpocock bump so pre-commit passes.