### PR TITLE
fix: migrate CI workflows from deprecated Node 20 actions

### DIFF
--- a/.github/workflows/bump-submodule-reusable.yml
+++ b/.github/workflows/bump-submodule-reusable.yml
@@ -49,12 +49,26 @@ jobs:
 
       - id: find-issue
         if: steps.detect.outputs.updated == 'true'
-        uses: micalevisk/last-issue-action@v2
+        uses: actions/github-script@v9
         with:
-          state: open
-          labels: |
-            submodule-bump
-            submodule:${{ inputs.submodule }}
+          script: |
+            const labels = ['submodule-bump', `submodule:${{ inputs.submodule }}`];
+            const { data: issues } = await github.rest.issues.listForRepo({
+              ...context.repo,
+              state: 'open',
+              labels: labels.join(','),
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 1,
+            });
+            const issue = issues[0];
+            if (issue) {
+              core.setOutput('has-found', 'true');
+              core.setOutput('issue-number', String(issue.number));
+            } else {
+              core.setOutput('has-found', 'false');
+              core.setOutput('issue-number', '');
+            }
 
       - id: write-issue-body
         if: steps.detect.outputs.updated == 'true' && steps.find-issue.outputs.has-found != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,9 +55,23 @@ jobs:
               });
               core.info(`Created ${tag}`);
             }
+      - name: Check if GitHub Release exists
+        id: release-exists
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const tag = `superpowers-overrides@${{ steps.overrides-ver.outputs.version }}`;
+            try {
+              await github.rest.repos.getReleaseByTag({ ...context.repo, tag });
+              core.setOutput('exists', 'true');
+              core.info(`Release ${tag} already exists`);
+            } catch (e) {
+              if (e.status !== 404) throw e;
+              core.setOutput('exists', 'false');
+            }
       - name: Create GitHub Release if missing
-        uses: softprops/action-gh-release@v2
+        if: steps.release-exists.outputs.exists != 'true'
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: superpowers-overrides@${{ steps.overrides-ver.outputs.version }}
           generate_release_notes: true
-          skip_if_release_exists: true


### PR DESCRIPTION
Replace last-issue-action with github-script for issue lookup and bump action-gh-release to v3 with an explicit release-exists guard.