### PR TITLE
fix(overrides): accept file_path in Cursor preToolUse enforce Read check

### DIFF
--- a/.changeset/cursor-enforce-file-path.md
+++ b/.changeset/cursor-enforce-file-path.md
@@ -1,0 +1,10 @@
+---
+"superpowers-overrides": patch
+---
+
+**Fix Cursor `preToolUse` enforce rejecting valid spor Read first tools**
+
+- Cursor sends Read paths in `tool_input.file_path`; enforce only read `.path`, denying legitimate `Read(.../spor-*/SKILL.md)` calls after detect.
+- Coalesce `path // file_path` in enforce generator; regenerate `override-cursor-enforce.sh`.
+- Deny message now leads with Read (Cursor) and mentions Skill (Claude Code).
+- Shell test covers Cursor-shaped `file_path` payload; CURSOR-SMOKE / cross-harness docs updated.

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .superpowers
 __pycache__/
 tmp
+.DS_Store

--- a/plugins/superpowers-overrides/bin/override-cursor-enforce.sh
+++ b/plugins/superpowers-overrides/bin/override-cursor-enforce.sh
@@ -73,7 +73,7 @@ tool_input=$(printf '%s' "$input" | jq -c '.tool_input // {}')
 allow=false
 
 if [ "$tool_name" = "Read" ]; then
-  read_path=$(printf '%s' "$tool_input" | jq -r '.path // ""')
+  read_path=$(printf '%s' "$tool_input" | jq -r '.path // .file_path // ""')
   if [ -n "$read_path" ] && printf '%s' "$read_path" | grep -Eiq "/skills/${override}/SKILL\.md$|/${override}/SKILL\.md$"; then
     allow=true
   fi
@@ -94,4 +94,4 @@ fi
 
 skill_ref="superpowers-overrides:${override}"
 jq -n --arg skill_ref "$skill_ref" \
-  '{permission:"deny", agent_message: ("MANDATORY OVERRIDE — oscaner hook intercepted this turn.\nYour FIRST tool call MUST be Skill(\"" + $skill_ref + "\").\nDo NOT call any other tool before it. Do NOT follow the skill body instructions below until after you have called the override.")}'
+  '{permission:"deny", agent_message: ("MANDATORY OVERRIDE — oscaner hook intercepted this turn.\nYour FIRST tool call MUST be Read(\"<path ending in /spor-<slug>/SKILL.md>\").\n(Claude Code: Skill(\"" + $skill_ref + "\") if available.)\nDo NOT call any other tool before it. Do NOT follow the skill body instructions below until after you have called the override.")}'

--- a/plugins/superpowers-overrides/build/render-cursor-hooks.sh
+++ b/plugins/superpowers-overrides/build/render-cursor-hooks.sh
@@ -250,7 +250,7 @@ tool_input=$(printf '%s' "$input" | jq -c '.tool_input // {{}}')
 allow=false
 
 if [ "$tool_name" = "Read" ]; then
-  read_path=$(printf '%s' "$tool_input" | jq -r '.path // ""')
+  read_path=$(printf '%s' "$tool_input" | jq -r '.path // .file_path // ""')
   if [ -n "$read_path" ] && printf '%s' "$read_path" | grep -Eiq "/skills/${{override}}/SKILL\\.md$|/${{override}}/SKILL\\.md$"; then
     allow=true
   fi
@@ -271,7 +271,7 @@ fi
 
 skill_ref="superpowers-overrides:${{override}}"
 jq -n --arg skill_ref "$skill_ref" \\
-  '{{permission:"deny", agent_message: ("MANDATORY OVERRIDE — oscaner hook intercepted this turn.\\nYour FIRST tool call MUST be Skill(\\"" + $skill_ref + "\\").\\nDo NOT call any other tool before it. Do NOT follow the skill body instructions below until after you have called the override.")}}'
+  '{{permission:"deny", agent_message: ("MANDATORY OVERRIDE — oscaner hook intercepted this turn.\\nYour FIRST tool call MUST be Read(\\"<path ending in /spor-<slug>/SKILL.md>\\").\\n(Claude Code: Skill(\\"" + $skill_ref + "\\") if available.)\\nDo NOT call any other tool before it. Do NOT follow the skill body instructions below until after you have called the override.")}}'
 '''
 
 detect_out.write_text(detect_script)

--- a/plugins/superpowers-overrides/docs/CURSOR-SMOKE.md
+++ b/plugins/superpowers-overrides/docs/CURSOR-SMOKE.md
@@ -25,6 +25,8 @@ All items must pass before penf is considered shipped. Check tool trace in agent
 
 Valid first tool after detect: **`Read`** with path ending in `/spor-<slug>/SKILL.md`, or **`Skill`** with `superpowers-overrides:spor-<slug>`. Any other first tool (Grep, Shell, Write, Read upstream SKILL, etc.) must be **denied** with MANDATORY OVERRIDE message.
 
+> **Cursor payload note:** `preToolUse` Read input uses `tool_input.file_path` (not `.path`). Enforce accepts either field.
+
 ### `conversation_id` note (deferred finding)
 
 Detect and enforce resolve pending via the **same** `session_key`: `conversation_id` ?? `session_id` ?? `sha256(prompt)[:16]`. When smoke-testing, confirm in Hook Execution Log that **both** hooks receive the same `conversation_id` on the same turn. If `preToolUse` stdin lacks `conversation_id` (and no `session_id` fallback), enforce will not find the pending file written by detect → enforcement silently allows. File a Cursor bug if observed; rules self-check remains fallback.

--- a/plugins/superpowers-overrides/docs/cross-harness-overrides.md
+++ b/plugins/superpowers-overrides/docs/cross-harness-overrides.md
@@ -39,7 +39,7 @@ Override-first is enforced by **plugin-bundled hooks** plus project self-check r
 | Hook | Handler | Role |
 |------|---------|------|
 | `beforeSubmitPrompt` (`UserPromptSubmit`) | `bin/override-cursor-detect.sh` | Match bare `/brainstorming`, `/spor-*`, `superpowers:*`, upstream SKILL attach paths → write pending state |
-| `preToolUse` (no matcher) | `bin/override-cursor-enforce.sh` | If pending exists: **allow** first `Read` (spor SKILL path) or `Skill` (`superpowers-overrides:spor-*`); **deny** all other first tools |
+| `preToolUse` (no matcher) | `bin/override-cursor-enforce.sh` | If pending exists: **allow** first `Read` (spor SKILL path via `tool_input.path` or `tool_input.file_path`) or `Skill` (`superpowers-overrides:spor-*`); **deny** all other first tools |
 
 Cursor cannot inject context on submit (no `additional_context` on `beforeSubmitPrompt`). Detect writes pending; enforce blocks wrong first tools.
 

--- a/plugins/superpowers-overrides/tests/override-cursor-enforce.test.sh
+++ b/plugins/superpowers-overrides/tests/override-cursor-enforce.test.sh
@@ -17,6 +17,12 @@ allow=$(printf '%s' "{\"conversation_id\":\"conv-e1\",\"tool_name\":\"Read\",\"t
 echo "$allow" | jq -e '.permission == "allow"' >/dev/null
 [ ! -f "$PENDING_ROOT/conv-e1.json" ] || { echo "pending not cleared"; exit 1; }
 
+# Cursor Read payload uses file_path not path
+printf '%s' '{"conversation_id":"conv-e1b","prompt":"/brainstorming","attachments":[]}' | "$DETECT" >/dev/null
+allow_fp=$(printf '%s' "{\"conversation_id\":\"conv-e1b\",\"tool_name\":\"Read\",\"tool_input\":{\"file_path\":\"$SPOR_SKILL\"}}" | "$ENFORCE")
+echo "$allow_fp" | jq -e '.permission == "allow"' >/dev/null
+[ ! -f "$PENDING_ROOT/conv-e1b.json" ] || { echo "pending not cleared (file_path)"; exit 1; }
+
 # Skill invocation as valid first tool
 printf '%s' '{"conversation_id":"conv-e2","prompt":"/brainstorming","attachments":[]}' | "$DETECT" >/dev/null
 allow_skill=$(printf '%s' '{"conversation_id":"conv-e2","tool_name":"Skill","tool_input":{"skill":"superpowers-overrides:spor-brainstorming"}}' | "$ENFORCE")


### PR DESCRIPTION
Cursor sends Read paths in tool_input.file_path; enforce only read .path, denying valid spor SKILL reads. Coalesce both fields, update deny copy, and add a shell test for the Cursor payload shape.