### PR TITLE
fix: sync PR runs when main leads develop after version merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 #   develop accumulates .changeset/*.md → develop→main PR → push main
 #   → changesets/action opens Version PR (target main)
 #   → merge Version PR → publish + tag + GitHub Release
-#   → sync PR main→develop when main is ahead of develop
+#   → sync PR main→develop when main is ahead of develop (always checked post-release)
 name: Release
 
 on:
@@ -84,14 +84,14 @@ jobs:
           tag_name: superpowers-overrides@${{ steps.overrides-ver.outputs.version }}
           generate_release_notes: true
       - name: Check if develop is behind main
-        if: steps.changesets.outputs.published == 'true' || steps.gh-release.outcome == 'success'
         id: needs-sync
         run: |
           git fetch origin main develop
           ahead=$(git rev-list --count origin/develop..origin/main)
           echo "ahead=$ahead" >> "$GITHUB_OUTPUT"
           echo "needs_sync=$([ "$ahead" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
-      - name: Prepare main → develop back-merge
+          echo "main is $ahead commit(s) ahead of develop"
+      - name: Prepare and push sync branch
         if: steps.needs-sync.outputs.needs_sync == 'true'
         run: |
           git fetch origin main develop
@@ -99,6 +99,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B chore/sync-main-to-develop origin/develop
           git merge origin/main -m "chore: sync main release back to develop"
+          git push origin chore/sync-main-to-develop --force-with-lease
       - name: Open sync PR main → develop
         if: steps.needs-sync.outputs.needs_sync == 'true'
         uses: peter-evans/create-pull-request@v8


### PR DESCRIPTION
Remove the published/gh-release gate that skipped sync after Version PR merges, and push the sync branch before create-pull-request so the first run does not fail on a missing remote branch.