### PR TITLE
chore: sync main release back to develop

### DIFF
--- a/.changeset/branch-rules-version-scheme.md
+++ b/.changeset/branch-rules-version-scheme.md
@@ -1,5 +1,0 @@
----
-"superpowers-overrides": major
----
-
-BREAKING: Overrides version scheme is now three-segment `{superpowers-semver}-overrides.{major}.{minor}.{patch}` (e.g. `6.2.0-overrides.0.15.0`). Legacy single-counter `{base}-overrides.{N}` is rejected by release validation. Any superpowers semver segment change resets overrides to `{new-base}-overrides.0.0.0`.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -68,7 +68,7 @@
         "email": "oscaner1997@gmail.com"
       },
       "license": "MIT",
-      "version": "6.2.0-overrides.0.15.0",
+      "version": "6.2.0-overrides.0.15.1",
       "category": "workflow",
       "tags": [
         "superpowers",

--- a/.cursor/rules/superpowers-overrides.mdc
+++ b/.cursor/rules/superpowers-overrides.mdc
@@ -1,7 +1,7 @@
 ---
 description: superpowers-overrides self-check for Cursor — intercept upstream superpowers skills
 alwaysApply: true
-superpowers-overrides-version: 6.2.0-overrides.0.15.0
+superpowers-overrides-version: 6.2.0-overrides.0.15.1
 ---
 
 ## superpowers-overrides self-check (Cursor)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- superpowers-overrides-version: 6.2.0-overrides.0.15.0 -->
+<!-- superpowers-overrides-version: 6.2.0-overrides.0.15.1 -->
 ## superpowers-overrides self-check
 
 Before your first tool call in ANY turn, run this check — no exceptions:

--- a/marketplace/source.json
+++ b/marketplace/source.json
@@ -75,7 +75,7 @@
     },
     {
       "name": "superpowers-overrides",
-      "version": "6.2.0-overrides.0.15.0",
+      "version": "6.2.0-overrides.0.15.1",
       "description": "Personal overrides for the superpowers plugin that force delegation to other skills.",
       "author": {
         "name": "Oscaner Miao",

--- a/plugins/superpowers-overrides/.claude-plugin/plugin.json
+++ b/plugins/superpowers-overrides/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "superpowers-overrides",
-  "version": "6.2.0-overrides.0.15.0",
+  "version": "6.2.0-overrides.0.15.1",
   "skills": "./skills/"
 }

--- a/plugins/superpowers-overrides/.codex-plugin/plugin.json
+++ b/plugins/superpowers-overrides/.codex-plugin/plugin.json
@@ -2,7 +2,7 @@
   "_generated": "plugins/superpowers-overrides/build/render-codex-manifest.sh \u2014 do not edit",
   "name": "superpowers-overrides",
   "description": "Personal overrides for the superpowers plugin that force delegation to other skills.",
-  "version": "6.2.0-overrides.0.15.0",
+  "version": "6.2.0-overrides.0.15.1",
   "author": {
     "name": "Oscaner Miao",
     "email": "oscaner1997@gmail.com"

--- a/plugins/superpowers-overrides/.cursor-plugin/plugin.json
+++ b/plugins/superpowers-overrides/.cursor-plugin/plugin.json
@@ -3,7 +3,7 @@
   "name": "superpowers-overrides",
   "displayName": "Superpowers Overrides",
   "description": "Personal overrides for the superpowers plugin that force delegation to other skills.",
-  "version": "6.2.0-overrides.0.15.0",
+  "version": "6.2.0-overrides.0.15.1",
   "author": {
     "name": "Oscaner Miao",
     "email": "oscaner1997@gmail.com"

--- a/plugins/superpowers-overrides/CHANGELOG.md
+++ b/plugins/superpowers-overrides/CHANGELOG.md
@@ -1,5 +1,12 @@
 # superpowers-overrides
 
+## 6.2.0-overrides.0.15.1
+
+### Patch Changes
+
+- BREAKING: Overrides version scheme is now three-segment `{superpowers-semver}-overrides.{major}.{minor}.{patch}` (e.g. `6.2.0-overrides.0.15.0`). Legacy single-counter `{base}-overrides.{N}` is rejected by release validation. Any superpowers semver segment change resets overrides to `{new-base}-overrides.0.0.0`.
+
+
 ## 6.2.0-overrides.0.15.0
 
 ### Patch Changes

--- a/plugins/superpowers-overrides/build/generated/claude-self-check.md
+++ b/plugins/superpowers-overrides/build/generated/claude-self-check.md
@@ -1,4 +1,4 @@
-<!-- superpowers-overrides-version: 6.2.0-overrides.0.15.0 -->
+<!-- superpowers-overrides-version: 6.2.0-overrides.0.15.1 -->
 ## superpowers-overrides self-check
 
 Before your first tool call in ANY turn, run this check — no exceptions:

--- a/plugins/superpowers-overrides/build/generated/cursor-self-check.mdc
+++ b/plugins/superpowers-overrides/build/generated/cursor-self-check.mdc
@@ -1,7 +1,7 @@
 ---
 description: superpowers-overrides self-check for Cursor — intercept upstream superpowers skills
 alwaysApply: true
-superpowers-overrides-version: 6.2.0-overrides.0.15.0
+superpowers-overrides-version: 6.2.0-overrides.0.15.1
 ---
 
 ## superpowers-overrides self-check (Cursor)

--- a/plugins/superpowers-overrides/package.json
+++ b/plugins/superpowers-overrides/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superpowers-overrides",
-  "version": "6.2.0-overrides.0.15.0",
+  "version": "6.2.0-overrides.0.15.1",
   "private": true,
   "description": "Personal overrides for the superpowers plugin that force delegation to other skills.",
   "author": {


### PR DESCRIPTION
Back-merge release commits from main into develop after Version PR #61. Uses chore/sync-main-to-develop (develop merged with main) because head=main stays out-of-date when branches diverged.