### PR TITLE
docs: document CLI agent session traceability (H6.6)

### DIFF
--- a/.changeset/sdd-gate-shell-consistency.md
+++ b/.changeset/sdd-gate-shell-consistency.md
@@ -1,0 +1,5 @@
+---
+"superpowers-overrides": minor
+---
+
+SDD orchestrator gate shell/workspace consistency + stale-workspace hijack prevention (issue #53). Read-only git diagnostics (`git status`/`git diff`/`git log`/`git show`/`git rev-parse`/`git branch`/`git remote`/`git ls-files`/`git diff-tree`) now allowed during active tasks, hardened against compound commands and mutating sub-verbs; deny message upgraded to a full allowlist matrix. Stale workspace hijack prevented via `TASK_BASE` git-object check and bound-workspace priority. Gate test fixtures isolated under `tests/fixtures/sdd-gate/`, full allow/deny matrix smoke test added and mounted in CI.

--- a/.changeset/sdd-session-traceability.md
+++ b/.changeset/sdd-session-traceability.md
@@ -1,0 +1,5 @@
+---
+"superpowers-overrides": patch
+---
+
+Document why SDD CLI agents are not traceable via /resume — H6.6 in the reference doc + shell comments.

--- a/docs/superpowers/plans/2026-08-07-sdd-gate-shell-consistency.md
+++ b/docs/superpowers/plans/2026-08-07-sdd-gate-shell-consistency.md
@@ -1,0 +1,595 @@
+# SDD gate Shell/Write 一致性 + 防劫持 实施计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 修复 SDD PreToolUse gate 的 Shell/Write 不一致（issue #53）并加固防劫持：(a) 只读 git 诊断 Bash 可用 + deny 消息升级为多行 allowlist 矩阵；(b) TASK_BASE 必须真实 git object + bound-ws 优先，旧 workspace 不再劫持新 session；(c) 全矩阵 smoke 测试 + fixture 隔离到 `tests/fixtures/sdd-gate/`。
+
+**Architecture:** 核心改动集中在 `bin/lib/sdd-orchestrator-gate.sh`（共享单源，两个 harness adapter 零改动自动继承）。T1 改 shell 一致性（`sdd_shell_allowed` 重命名+扩展 + `sdd_git_verb_allowed` + deny 消息矩阵）；T2 改防劫持（`sdd_git_object_exists` + `sdd_brief_has_task_base` git-object 校验 + `sdd_gate_phase` 单一解析点/bound-ws 优先）。T1→T2→T3 串行（**T1/T2/T3 都改同一 lib**：T1 shell、T2 防劫持、T3 `SDD_GATE_FIXTURES_ROOT` 覆盖）。T3 建 fixture 基础设施 + 改造现有两个 gate 测试；T4 新增全矩阵 smoke + CI 挂载；T5 文档（sdd-h6-reference / cross-harness-overrides / spor-SDD Rule 0a）；T6 清理 dogfood-test + 全量 validate。T4/T5 依赖 T1+T2+T3。
+
+**Tech Stack:** Bash、jq、git；验证命令 `pnpm run validate`
+
+## Global Constraints
+
+- 不改 adapter JSON 格式（`hookSpecificOutput.permissionDecision` / `.permission`）
+- 不改 H6 four-mode 语义、`sdd-run-task-*.sh` 行为
+- **No duplicated allowlist logic** — 判定逻辑放共享 lib，不保留 `sdd_bash_allowed` 与 `sdd_shell_allowed` 两个函数
+- 不改 fail-open 语义（无 jq / 无 pending → allow）
+- spor-SDD 保持 ≤160 行（当前 94 行，Rule 0a 补一行安全）
+- 解析失败 → deny（fail-closed）
+- `git cat-file -e` 必须 `git -C "$repo_root"`（CWD 无关）
+- 提交信息使用 conventional commits，无 attribution/co-author trailer
+
+---
+
+## File Map
+
+| 文件 | 操作 | Task |
+|------|------|------|
+| `plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh` | Modify | T1, T2, T3 |
+| `plugins/superpowers-overrides/tests/fixtures/sdd-gate/` | Create | T3 |
+| `plugins/superpowers-overrides/tests/override-claude-sdd-gate.test.sh` | Modify | T3 |
+| `plugins/superpowers-overrides/tests/override-cursor-sdd-gate.test.sh` | Modify | T3 |
+| `plugins/superpowers-overrides/tests/sdd-gate-allow-deny-smoke.sh` | Create | T4 |
+| `scripts/ci-validate.sh` | Modify | T4 |
+| `plugins/superpowers-overrides/docs/sdd-h6-reference.md` | Modify | T5 |
+| `plugins/superpowers-overrides/docs/cross-harness-overrides.md` | Modify | T5 |
+| `plugins/superpowers-overrides/skills/spor-subagent-driven-development/SKILL.md` | Modify | T5 |
+| `.superpowers/sdd/dogfood-test/` | Delete | T6 |
+
+---
+
+### Task 1: `sdd_shell_allowed` 重命名+扩展 + `sdd_git_verb_allowed` + deny 消息矩阵
+
+**Files:**
+- Modify: `plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh`
+
+**Interfaces:**
+- Consumes: 无（首个改动）
+- Produces: shell 一致性；`sdd_gate_decide` 唯一调用点更新；deny 消息多行矩阵
+
+- [ ] **Step 1: 重命名 `sdd_bash_allowed` → `sdd_shell_allowed` 并扩展只读 git 动词**
+
+  将现有 `sdd_bash_allowed()`（当前第 77-84 行）重命名为 `sdd_shell_allowed()`，在其 allowlist `case` 之后追加只读 git 判定：
+
+  ```bash
+  sdd_shell_allowed() {
+    local cmd="$1"
+    case "$cmd" in
+      *sdd-run-task-*|*sdd-workspace*|*task-brief*|*review-package*) return 0 ;;
+    esac
+    if sdd_git_verb_allowed "$cmd"; then
+      return 0
+    fi
+    return 1
+  }
+  ```
+
+  更新 `sdd_gate_decide` 里 shell 分支的调用点：`sdd_bash_allowed "$cmd"` → `sdd_shell_allowed "$cmd"`。**不保留 `sdd_bash_allowed` 函数**（避免重复 allowlist 逻辑）。
+
+- [ ] **Step 2: 新增 `sdd_git_verb_allowed()` — 提取 git 子命令并查只读白名单**
+
+  新增函数（放在 `sdd_shell_allowed` 附近）：
+
+  ```bash
+  # 提取 git 子命令并查只读白名单。提取失败 → return 1（deny，fail-closed）。
+  # 支持：git <verb>、git -C <path> <verb>、git --git-dir=<path> <verb>
+  # v1 不支持：git -C <path> -c k=v <verb>（-c 配置选项）→ 提取失败 → deny
+  sdd_git_verb_allowed() {
+    local cmd="$1" verb=""
+    local -a tokens=()
+    read -r -a tokens <<<"$cmd"
+    [[ "${tokens[0]:-}" == "git" ]] || return 1
+    local i=1
+    while [[ $i -lt ${#tokens[@]} ]]; do
+      case "${tokens[$i]}" in
+        -C)
+          i=$((i + 2))        # 跳过 -C 及其路径
+          continue
+          ;;
+        --git-dir=*)          # 跳过 --git-dir=<path>
+          i=$((i + 1))
+          continue
+          ;;
+        -*)                   # 其它未知 flag → 提取失败 → deny
+          return 1
+          ;;
+        *)
+          verb="${tokens[$i]}"
+          break
+          ;;
+      esac
+    done
+    [[ -n "$verb" ]] || return 1
+    case "$verb" in
+      status|diff|log|show|rev-parse|branch|remote|ls-files|diff-tree) return 0 ;;
+      *) return 1 ;;
+    esac
+  }
+  ```
+
+- [ ] **Step 3: 更新 `sdd_deny_message()` 为多行 allowlist 矩阵**
+
+  将 `sdd_deny_message()`（当前第 212-222 行）替换为（**用 `<<-EOF`**，容忍前导 tab，保证 code block 内缩进也能正确终止 heredoc）：
+
+  ```bash
+  sdd_deny_message() {
+    local harness="$1" task_num="$2" plan_basename="$3"
+    local plugin_root
+    plugin_root="$(sdd_plugin_root_from_lib)"
+    cat <<-EOF
+  SDD orchestrator gate — direct repo edits forbidden during active task.
+
+  Allowed Bash (read-only diagnostics):
+    git status / git diff / git log / git show / git rev-parse / git branch / git remote
+    git ls-files / git diff-tree
+    ${plugin_root}/bin/sdd-run-task-${harness}.sh
+    sdd-workspace / task-brief / review-package
+
+  Allowed Write:
+    .superpowers/sdd/${plan_basename}/
+
+  Repo changes flow only through:
+    ${plugin_root}/bin/sdd-run-task-${harness}.sh --task ${task_num} --mode implement
+
+  Full matrix: docs/sdd-h6-reference.md (SDD gate matrix)
+  See spor-SDD Rule 0a item 4.
+  EOF
+  }
+  ```
+
+  > `<<-EOF` 允许前导 tab；文本行用 tab 缩进对齐函数体。若实现环境偏好左对齐文本，也可用 `<<EOF` + 左对齐（参考当前实现第 216-221 行）。两种都需保证 `EOF` 终结符无多余缩进/空格。
+
+- [ ] **Step 4: 验证 T1 改动**
+
+  ```bash
+  cd /Users/kang/Projects/oscaner-skills
+  bash -n plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh
+  # 快速行为验证：只读 git allow、变更类 git deny
+  ROOT=plugins/superpowers-overrides
+  GATE=$ROOT/bin/override-claude-sdd-gate.sh
+  ACT=$ROOT/bin/sdd-session-activate.sh
+  PENDING="${TMPDIR:-/tmp}/oscaner-superpowers-overrides/pending-sdd"
+  WS="$PWD/.superpowers/sdd/dogfood-test"
+  rm -f "$PENDING"/*.json
+  "$ACT" bind conv-t1 "$PWD" "docs/superpowers/plans/x.md" "$WS"
+  echo 'TASK_BASE: 0dc7387' > "$WS/task-1-brief.md"
+  printf '%s' "{\"session_id\":\"conv-t1\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git status --short\"}}" | "$GATE" | jq -r '.hookSpecificOutput.permissionDecision'   # 预期 allow
+  printf '%s' "{\"session_id\":\"conv-t1\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git add .\"}}" | "$GATE" | jq -r '.hookSpecificOutput.permissionDecision'  # 预期 deny
+  printf '%s' "{\"session_id\":\"conv-t1\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git add .\"}}" | "$GATE" | jq -r '.hookSpecificOutput.permissionDecisionReason'   # 预期含矩阵
+  rm -f "$WS/task-1-handoff.json" "$PENDING"/conv-t1.json
+  ```
+
+  预期：`git status` → `allow`；`git add .` → `deny`；deny 消息含 "Allowed Bash" / "git show" / "Allowed Write"。
+
+- [ ] **Step 5: 提交**
+
+  ```bash
+  git add plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh
+  git commit -m "fix: allow read-only git diagnostics in sdd orchestrator gate"
+  ```
+
+---
+
+### Task 2: 防劫持 — `sdd_git_object_exists` + `sdd_brief_has_task_base` git-object 校验 + `sdd_gate_phase` 单一解析点/bound-ws 优先
+
+**Files:**
+- Modify: `plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh`
+
+**Interfaces:**
+- Consumes: T1（同文件）
+- Produces: 旧 workspace（stub `TASK_BASE: abc`）不再劫持新 session；bound-ws 优先
+
+- [ ] **Step 1: 新增 `sdd_git_object_exists()` — git-object 校验（绑定 repo_root）**
+
+  ```bash
+  # git cat-file 必须绑定 repo_root（CWD 无关）。实证：bare `git cat-file -e` 依赖 CWD 是 git 仓库。
+  sdd_git_object_exists() {
+    local repo_root="$1" sha="$2"
+    git -C "$repo_root" cat-file -e "$sha" 2>/dev/null   # 真实 SHA → 0；stub 'abc' → 1
+  }
+  ```
+
+- [ ] **Step 2: `sdd_brief_has_task_base()` 加 git-object 校验（签名变更，加 repo_root）**
+
+  ```bash
+  sdd_brief_has_task_base() {
+    local brief="$1" repo_root="$2"
+    [[ -f "$brief" ]] || return 1
+    local sha
+    sha="$(sed -nE 's/^TASK_BASE: //p' "$brief" | head -1 | tr -d ' \r')"
+    [[ -n "$sha" ]] || return 1
+    sdd_git_object_exists "$repo_root" "$sha"
+  }
+  ```
+
+- [ ] **Step 3: 更新 `sdd_brief_has_task_base` 全部调用点，传入 `repo_root`**
+
+  `grep -n "sdd_brief_has_task_base" plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh` 定位。调用点：
+  - `sdd_find_active_workspace()` — 已有 `repo_root` 参数，传入
+  - `sdd_gate_phase()` — 已有 `repo_root`，传入
+  - `sdd_frontier_task()` — **新增 `repo_root` 参数**，从 `sdd_gate_phase` 和 `sdd_active_task_num` 调用点传入
+
+  逐个更新为 `sdd_brief_has_task_base "$brief" "$repo_root"`。
+
+  **`repo_root` 传播链（必须完整，否则 git-object 校验拿空 repo_root）**：
+  - `sdd_frontier_task()` 签名 → `sdd_frontier_task "$workspace" "$repo_root"`
+  - `sdd_active_task_num()`（当前第 207 行）签名 → `sdd_active_task_num "$workspace" "$repo_root"`，内部调 `sdd_frontier_task "$workspace" "$repo_root"`
+  - `sdd_gate_decide` 内 `sdd_active_task_num` 两个调用点（当前第 308、324 行）→ `task_num="$(sdd_active_task_num "$active_ws" "$repo_root")"`
+
+- [ ] **Step 4: `sdd_gate_phase()` 单一解析点 + bound-ws 优先**
+
+  `sdd_gate_decide` 保持单一解析点（当前第 291-295 行已是）：
+  ```bash
+  workspace="$(sdd_resolve_workspace "$repo_root" "$pending" || true)"
+  active_ws="$workspace"
+  if [[ -z "$active_ws" ]]; then
+    active_ws="$(sdd_find_active_workspace "$repo_root" || true)"   # git-object 过滤后 stub 不激活
+  fi
+  phase="$(sdd_gate_phase "$repo_root" "$active_ws" "$pending")"   # 传入已解析 active_ws
+  ```
+
+  修改 `sdd_gate_phase()`：**接收已解析的 `$workspace`，删除内部二次 resolve/find**（当前第 176-184 行）：
+  ```bash
+  sdd_gate_phase() {
+    local repo_root="$1" workspace="$2" pending_json="$3"
+    local n brief next_brief active_ws
+    active_ws="$workspace"    # 直接使用已解析值
+    if [[ -z "$active_ws" ]]; then
+      printf 'orchestrating\n'
+      return 0
+    fi
+    ...
+  }
+  ```
+
+  > **注意**：minimal 模式（未 bind）的 `find_active_workspace` 由 `sdd_gate_decide` 的单一解析点保证；若 `active_ws` 为空，`sdd_gate_phase` 返回 `orchestrating`（行为保留）。
+
+- [ ] **Step 5: 验证 T2 改动**
+
+  ```bash
+  cd /Users/kang/Projects/oscaner-skills
+  bash -n plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh
+  ROOT=plugins/superpowers-overrides
+  GATE=$ROOT/bin/override-claude-sdd-gate.sh
+  ACT=$ROOT/bin/sdd-session-activate.sh
+  PENDING="${TMPDIR:-/tmp}/oscaner-superpowers-overrides/pending-sdd"
+  WS="$PWD/.superpowers/sdd/dogfood-test"
+  NEW_WS="$PWD/.superpowers/sdd/t2-probe-ws"      # 用于区分的"新 workspace"路径
+  rm -f "$PENDING"/*.json
+  rm -rf "$NEW_WS"
+  # stub SHA（abc）不应激活 → phase=orchestrating
+  echo 'TASK_BASE: abc' > "$WS/task-1-brief.md"
+  "$ACT" minimal conv-t2 "$PWD"
+  # 探针：写"新 workspace"路径。orchestrating 下该路径属于 .superpowers/sdd/** → allow；
+  #       若被劫持成 task_active，该路径非 active_ws → deny。这是唯一能区分的探针。
+  printf '%s' "{\"session_id\":\"conv-t2\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$NEW_WS/progress.md\",\"content\":\"x\"}}" | "$GATE" | jq -r '.hookSpecificOutput.permissionDecision'   # 预期 allow（orchestrating，未被劫持）
+  # 真实 SHA 应激活 → phase=task_active，active_ws=dogfood-test
+  SHA=$(git rev-parse --short HEAD)
+  echo "TASK_BASE: $SHA" > "$WS/task-1-brief.md"
+  "$ACT" minimal conv-t2b "$PWD"
+  printf '%s' "{\"session_id\":\"conv-t2b\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$NEW_WS/progress.md\",\"content\":\"x\"}}" | "$GATE" | jq -r '.hookSpecificOutput.permissionDecision'   # 预期 deny（task_active，NEW_WS 非 active_ws）
+  rm -rf "$NEW_WS"
+  rm -f "$WS/task-1-brief.md"   # 清理：避免真实 SHA brief 残留（T2~T6 期间劫持态）
+  rm -f "$PENDING"/conv-t2.json "$PENDING"/conv-t2b.json
+  ```
+
+  预期：stub `abc` → 写 `t2-probe-ws` `allow`（phase=orchestrating，未被劫持）；真实 SHA → `deny`（task_active，probe 路径非 active_ws）。**注意**：repo 路径（如 `plugins/foo.txt`）在 orchestrating 下本就是 deny（非 `.superpowers/sdd/**`），不能用作劫持探针。
+
+  > **环境鲁棒性**：若本 plan 经 SDD 执行，`sdd_find_active_workspace` 可能扫到本 plan 自身的活 workspace（真实 SHA + 无 APPROVED handoff）→ stub 探针的 allow 会被误判为 deny。若出现此情况，改用 `bind` 模式锚定探针 workspace：`"$ACT" bind conv-t2 "$PWD" "docs/x.md" "$NEW_WS"` 后再探针（`sdd_resolve_workspace` 钉住 active_ws，不受扫描结果干扰）。
+
+- [ ] **Step 6: 提交**
+
+  ```bash
+  git add plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh
+  git commit -m "fix: prevent stale sdd workspace hijack via git-object check"
+  ```
+
+---
+
+### Task 3: fixture 基础设施 + 改造现有两个 gate 测试
+
+**Files:**
+- Create: `plugins/superpowers-overrides/tests/fixtures/sdd-gate/`（场景根）
+- Modify: `plugins/superpowers-overrides/tests/override-claude-sdd-gate.test.sh`
+- Modify: `plugins/superpowers-overrides/tests/override-cursor-sdd-gate.test.sh`
+
+**Interfaces:**
+- Consumes: T1, T2（fixture 依赖新 gate 行为）
+- Produces: 隔离的测试 workspace；现有测试不再污染真实 `.superpowers/sdd/`
+
+- [ ] **Step 1: 创建 fixture 场景根**
+
+  **路径约束（实证）**：`.superpowers` 被根 `.gitignore`（第 4 行，无斜杠 → 匹配任意深度）忽略；fixture 目录若 `git init` 会变嵌套 git 仓库（`git add` 记成 gitlink，fresh clone 为空）。因此 fixture 模板**不用** `.superpowers/sdd/` 路径、**不做** `git init`——用普通目录 `sdd/` 存放，测试运行时把 `SDD_GATE_FIXTURES_ROOT` 指向副本并 `git init`（git-object 校验绑定**真实 repo** 的 repo_root，fixture 无需是 git 仓库）。
+
+  ```
+  tests/fixtures/sdd-gate/                      # 普通目录，全部被 git 跟踪
+    orchestrating/sdd/orchestrating-ws/         # 空目录（无 brief → 不激活）
+    active/sdd/active-ws/task-1-brief.md        # 内容: "TASK_BASE: <SHA>\n"
+    complete/sdd/complete-ws/
+      task-1-brief.md                           # 内容: "TASK_BASE: <SHA>\n"
+      task-1-handoff.json                       # 内容: {"status":"APPROVED","phase":"implement","task":1,"commits":{"base":"<SHA>","head":"<SHA>"}}
+    stub/sdd/stub-ws/task-1-brief.md            # 内容: "TASK_BASE: abc\n"
+  ```
+
+  创建命令（写 brief/handoff 文件，**不做 `git init`**）：
+
+  ```bash
+  cd plugins/superpowers-overrides/tests/fixtures/sdd-gate
+  # orchestrating：空 workspace（无需文件）
+  mkdir -p orchestrating/sdd/orchestrating-ws
+  # active：TASK_BASE 占位符，无 handoff
+  mkdir -p active/sdd/active-ws
+  printf 'TASK_BASE: <SHA>\n' > active/sdd/active-ws/task-1-brief.md
+  # complete：TASK_BASE + APPROVED handoff
+  mkdir -p complete/sdd/complete-ws
+  printf 'TASK_BASE: <SHA>\n' > complete/sdd/complete-ws/task-1-brief.md
+  printf '%s\n' '{"status":"APPROVED","phase":"implement","task":1,"commits":{"base":"<SHA>","head":"<SHA>"}}' > complete/sdd/complete-ws/task-1-handoff.json
+  # stub：TASK_BASE: abc（字面量，断言不激活）
+  mkdir -p stub/sdd/stub-ws
+  printf 'TASK_BASE: abc\n' > stub/sdd/stub-ws/task-1-brief.md
+  ```
+
+  > **确认**：`git status` 下这些文件应被跟踪（路径不含 `.superpowers`）。用 `git check-ignore` 验证无命中。
+
+- [ ] **Step 2: gate lib 增加 `SDD_GATE_FIXTURES_ROOT` 覆盖**
+
+  在 `sdd-orchestrator-gate.sh` 里，凡解析 `.superpowers/sdd` 的地方支持覆盖。`sdd_find_active_workspace` **签名改为接收 `sdd_root`**（替代 `repo_root` 内联拼接）：
+
+  ```bash
+  # sdd_find_active_workspace() — 签名: sdd_find_active_workspace "$sdd_root"
+  sdd_find_active_workspace() {
+    local sdd_root="$1" dir brief n handoff
+    [[ -d "$sdd_root" ]] || return 1
+    for dir in "$sdd_root"/*/; do
+      ...
+    done
+  }
+  ```
+
+  **必须更新的调用点**（`grep -n "sdd_find_active_workspace"` 定位）：
+  - `sdd_gate_decide`（T2 Step 4 加的单一解析点）→ `active_ws="$(sdd_find_active_workspace "$sdd_root" || true)"`
+  - `sdd_write_allowed` / `sdd_plan_basename` 里的 `.superpowers/sdd` 引用 → 用 `$sdd_root`
+
+  `sdd_root` 在 `sdd_gate_decide` 开头统一解析：
+  ```bash
+  local sdd_root="${SDD_GATE_FIXTURES_ROOT:-$repo_root/.superpowers/sdd}"
+  ```
+
+- [ ] **Step 3: 改造 `override-claude-sdd-gate.test.sh`**
+
+  移除对 `dogfood-test` 的写入（当前第 9、18 行），改为从 fixture 复制到临时目录 + 注入真实 SHA：
+
+  ```bash
+  FIXTURES="$ROOT/tests/fixtures/sdd-gate"
+  REPO="$(git -C "$ROOT/../.." rev-parse --show-toplevel)"
+  TMPFIX=$(mktemp -d)
+  trap 'rm -rf "$TMPFIX"' EXIT
+  cp -R "$FIXTURES/active/." "$TMPFIX/"
+  SHA=$(git -C "$REPO" rev-parse --short HEAD)
+  sed -i '' "s/TASK_BASE: <SHA>/TASK_BASE: $SHA/" "$TMPFIX/sdd/active-ws/task-1-brief.md"
+  # 副本需是 git 仓库（git-object 校验绑定 TMPFIX 作为 repo_root 时）
+  git -C "$TMPFIX" init -q && git -C "$TMPFIX" add -A && git -C "$TMPFIX" commit -qm "fixture" 2>/dev/null
+  export SDD_GATE_FIXTURES_ROOT="$TMPFIX/sdd"
+  ```
+
+  > **注意**：测试的 pending `repo_root` 必须指向 `$TMPFIX`（而非真实 repo），使 `git -C "$repo_root" cat-file -e "$SHA"` 在副本内可解析。用 `"$ACT" minimal conv-c1 "$TMPFIX"`。
+
+  断言保持不变（claude 测 `hookSpecificOutput.permissionDecision`）。
+
+- [ ] **Step 4: 改造 `override-cursor-sdd-gate.test.sh`**
+
+  同样移除 dogfood-test 依赖。cursor 测试（当前第 12-31 行）改为：
+  - `WS="$TMPFIX/sdd/active-ws"`（替代 `$REPO/.superpowers/sdd/dogfood-test`）
+  - `"$ACT" minimal conv-g1 "$TMPFIX"`（repo_root 指向副本）
+  - `"$ACT" bind conv-g1 "$TMPFIX" "dogfood-plan.md" "$WS"`（bind 到副本 active-ws）
+  - TASK_ACTIVE 场景用 `active` fixture（brief 已含真实 SHA）
+  - cursor 用 `conversation_id`、`tool_input.path`（保留）
+
+- [ ] **Step 5: 验证 T3**
+
+  ```bash
+  cd /Users/kang/Projects/oscaner-skills
+  bash plugins/superpowers-overrides/tests/override-claude-sdd-gate.test.sh
+  bash plugins/superpowers-overrides/tests/override-cursor-sdd-gate.test.sh
+  ```
+
+  预期：两个测试都输出 `OK — ...`。`git status` 确认 `.superpowers/sdd/` 无测试写入（stub 不再出现在真实树）；`git check-ignore` 确认 fixture 文件被跟踪。
+
+- [ ] **Step 6: 提交**
+
+  ```bash
+  git add plugins/superpowers-overrides/tests/fixtures/ \
+          plugins/superpowers-overrides/tests/override-claude-sdd-gate.test.sh \
+          plugins/superpowers-overrides/tests/override-cursor-sdd-gate.test.sh
+  git status   # 确认 fixture 文件出现在 staged（无 gitlink 警告、无 .superpowers 忽略）
+  git commit -m "test: isolate sdd gate fixtures from real workspace tree"
+  ```
+
+- [ ] **Step 5: 验证 T3**
+
+  ```bash
+  cd /Users/kang/Projects/oscaner-skills
+  bash plugins/superpowers-overrides/tests/override-claude-sdd-gate.test.sh
+  bash plugins/superpowers-overrides/tests/override-cursor-sdd-gate.test.sh
+  ```
+
+  预期：两个测试都输出 `OK — ...`。`git status` 确认 `.superpowers/sdd/` 无测试写入（stub 不再出现在真实树）。
+
+- [ ] **Step 6: 提交**
+
+  ```bash
+  git add plugins/superpowers-overrides/tests/
+  git commit -m "test: isolate sdd gate fixtures from real workspace tree"
+  ```
+
+---
+
+### Task 4: 全矩阵 smoke 测试 + CI 挂载
+
+**Files:**
+- Create: `plugins/superpowers-overrides/tests/sdd-gate-allow-deny-smoke.sh`
+- Modify: `scripts/ci-validate.sh`
+
+**Interfaces:**
+- Consumes: T1, T2, T3（smoke 依赖全部 gate 行为 + fixture）
+- Produces: 完整 allow/deny 矩阵回归测试
+
+- [ ] **Step 1: 创建 `sdd-gate-allow-deny-smoke.sh`**
+
+  覆盖 spec §设计 判定矩阵的每一行，用 fixture 场景根 + `SDD_GATE_FIXTURES_ROOT`。脚本骨架：
+
+  ```bash
+  #!/usr/bin/env bash
+  set -euo pipefail
+  ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+  GATE="$ROOT/bin/override-claude-sdd-gate.sh"
+  ACT="$ROOT/bin/sdd-session-activate.sh"
+  FIXTURES="$ROOT/tests/fixtures/sdd-gate"
+  REPO="$(git -C "$ROOT/../.." rev-parse --show-toplevel)"
+
+  fail() { echo "FAIL: $1"; exit 1; }
+  assert_allow() { ... }   # 断言 permissionDecision == allow
+  assert_deny() { ... }    # 断言 permissionDecision == deny
+
+  # 场景函数：复制 fixture 到临时目录，注入真实 SHA，设 SDD_GATE_FIXTURES_ROOT
+  setup_scenario() { ... }
+
+  # 矩阵断言（claude adapter JSON 形状）
+  # 1. 只读 git allow（orchestrating/task_active）
+  #    - `git status` / `git -C x status` / `git --git-dir=x status` / `git diff HEAD~1` → allow（AC1 边界用例）
+  #    - `git -C x -c k=v status` → deny（AC1 v1 超范围）
+  # 2. 变更类 git deny（`git add`/`git commit`/`git push`）
+  # 3. stub-ws 不激活 / active-ws 激活
+  # 4. bound-ws 不扫描无关 workspace
+  # 5. deny 消息含多行矩阵 + git show
+  # 6. task_complete 后 shell/Write allow
+
+  echo "OK — sdd-gate-allow-deny-smoke"
+  ```
+
+  每个场景用 `setup_scenario <场景名>` 复制对应 fixture 根 + 注入 SHA + 设 env。矩阵断言对照 spec §设计 判定矩阵表。
+
+- [ ] **Step 2: 在 `scripts/ci-validate.sh` 挂载 smoke**
+
+  在现有 gate 测试之后（第 61 行 `override-claude-sdd-gate.test.sh` 后）追加：
+
+  ```bash
+  ./plugins/superpowers-overrides/tests/sdd-gate-allow-deny-smoke.sh
+  ```
+
+- [ ] **Step 3: 验证 T4**
+
+  ```bash
+  cd /Users/kang/Projects/oscaner-skills
+  bash plugins/superpowers-overrides/tests/sdd-gate-allow-deny-smoke.sh
+  ```
+
+  预期：输出 `OK — sdd-gate-allow-deny-smoke`，无失败断言。
+
+- [ ] **Step 4: 提交**
+
+  ```bash
+  git add plugins/superpowers-overrides/tests/sdd-gate-allow-deny-smoke.sh scripts/ci-validate.sh
+  git commit -m "test: add sdd gate allow-deny matrix smoke test"
+  ```
+
+---
+
+### Task 5: 文档同步
+
+**Files:**
+- Modify: `plugins/superpowers-overrides/docs/sdd-h6-reference.md`
+- Modify: `plugins/superpowers-overrides/docs/cross-harness-overrides.md`
+- Modify: `plugins/superpowers-overrides/skills/spor-subagent-driven-development/SKILL.md`
+
+**Interfaces:**
+- Consumes: T1, T2（文档描述新 gate 行为）
+- Produces: orchestrator 可查阅的完整 gate 矩阵；Rule 0a 清单同步
+
+- [ ] **Step 1: `sdd-h6-reference.md` 新增 `## SDD gate matrix` 小节**
+
+  在 `docs/sdd-h6-reference.md` 追加（内容对照 spec §设计 判定矩阵 + 安全属性）：
+  - 完整 allow/deny 矩阵表（Write/Edit、Bash/Shell、其它工具）
+  - Shell 契约：只读 git 诊断可用、变更走 H6/Write、heredoc 被拒
+  - 防劫持说明：TASK_BASE 必须真实 git object（`git -C <repo> cat-file -e`）；bound-ws 优先
+  - `SDD_GATE_FIXTURES_ROOT` 测试覆盖开关
+
+- [ ] **Step 2: `cross-harness-overrides.md` 同步 gate 小节**
+
+  在现有「SDD orchestrator gate (p1-slim.2)」小节后补：
+  - 允许只读 git 诊断 Bash（白名单动词列表）
+  - deny 消息为多行 allowlist 矩阵
+  - 防劫持（git-object 校验 + bound-ws 优先）
+
+- [ ] **Step 3: `spor-subagent-driven-development/SKILL.md` Rule 0a 补一行**
+
+  在 Rule 0a item 4 的 Per-task 行后补一行说明（保持 ≤160 行，当前 94 行安全）：
+
+  ```markdown
+  **Shell 契约：** 只读 git 诊断（`git status`/`git diff`/`git log`/`git show`/`git rev-parse`/`git branch`/`git remote`/`git ls-files`/`git diff-tree`）可用；`TASK_BASE` 必须是真实 git SHA（gate 以 `git cat-file -e` 校验）。
+  ```
+
+- [ ] **Step 4: 验证 T5**
+
+  ```bash
+  cd /Users/kang/Projects/oscaner-skills
+  bash plugins/superpowers-overrides/tests/sdd-orchestrator-line-budget.test.sh   # 确认 spor-SDD ≤160
+  ```
+
+- [ ] **Step 5: 提交**
+
+  ```bash
+  git add plugins/superpowers-overrides/docs/sdd-h6-reference.md \
+          plugins/superpowers-overrides/docs/cross-harness-overrides.md \
+          plugins/superpowers-overrides/skills/spor-subagent-driven-development/SKILL.md
+  git commit -m "docs: document sdd gate allow-deny matrix"
+  ```
+
+---
+
+### Task 6: 清理 dogfood-test + 全量 validate
+
+**Files:**
+- Delete: `.superpowers/sdd/dogfood-test/`（gitignored，无提交风险）
+- Modify: `.superpowers/sdd/`（删除测试残留）
+
+**Interfaces:**
+- Consumes: T1–T5（全部改动就绪）
+- Produces: 干净的 `.superpowers/sdd/` 树 + validate 全绿
+
+- [ ] **Step 1: 删除 dogfood-test 及测试残留**
+
+  ```bash
+  rm -rf .superpowers/sdd/dogfood-test
+  # 确认无其他 stub brief 残留
+  find .superpowers/sdd -name 'task-*-brief.md' -exec grep -l '^TASK_BASE: abc' {} \;
+  ```
+
+  > 若其它旧 workspace 含真实 TASK_BASE（如已完成的 p1 系列），保留不动（它们有真实 SHA 或已完成，不劫持）。
+
+- [ ] **Step 2: 全量 validate**
+
+  ```bash
+  cd /Users/kang/Projects/oscaner-skills
+  pnpm run validate
+  ```
+
+  预期：`ALL PASS`。重点看 `override-claude-sdd-gate`、`override-cursor-sdd-gate`、新 smoke 三行通过。
+
+- [ ] **Step 3: 更新 spec §Smoke results 表格**
+
+  在 `docs/superpowers/specs/2026-08-07-sdd-gate-shell-consistency-design.md` 的 §Smoke results 填上实际 Pass 结果与日期。
+
+- [ ] **Step 4: 提交（含 spec smoke 更新）**
+
+  ```bash
+  git add docs/superpowers/specs/2026-08-07-sdd-gate-shell-consistency-design.md
+  git commit -m "docs: record sdd gate consistency smoke results"
+  ```
+
+---
+
+## 收尾
+
+- 全量 `pnpm run validate` 通过后，按仓库流程开 PR（目标分支 `develop`）。
+- spec + plan + tickets 三个文档同 slug：`2026-08-07-sdd-gate-shell-consistency`。

--- a/docs/superpowers/plans/2026-08-07-sdd-session-traceability.md
+++ b/docs/superpowers/plans/2026-08-07-sdd-session-traceability.md
@@ -1,0 +1,164 @@
+# H6 CLI Agent Session Traceability — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Document why SDD CLI agents are not traceable via `/resume`, and where to find the audit trail instead.
+
+**Architecture:** Documentation-only — one new numbered rule (H6.6) in the H6 reference doc + a one-line comment in each task-runner shell script. No code changes.
+
+**Tech Stack:** Markdown, shell (comment-only)
+
+## Global Constraints
+
+- No shell execution logic changes — invocation lines stay as-is
+- H6.5 forbidden list unchanged (`--resume` still banned)
+- H6.6 must match existing doc's numbered-rule style under H6
+- Shell comments must be per-harness (`-p` for claude, `--print` for cursor)
+- Conventional commits (`docs:` prefix)
+
+---
+
+### Task 1: Add H6.6 to sdd-h6-reference.md
+
+**Files:**
+- Modify: `plugins/superpowers-overrides/docs/sdd-h6-reference.md`
+
+**Interfaces:**
+- Produces: H6.6 numbered rule read by shell scripts (Task 2, Task 3) via `See H6.6.` pointer
+
+- [ ] **Step 1: Insert H6.6 after H6.5**
+
+In `plugins/superpowers-overrides/docs/sdd-h6-reference.md`, locate the H6.5 rule:
+
+```
+5. **Forbidden:** `--resume` or any CLI invocation that carries prior session history.
+```
+
+Append the following block immediately after that line (before any H7 heading):
+
+```
+6. **Session traceability:** CLI agents use one-shot print mode (`--print` / `--output-format text`), which does NOT register sessions in the `/resume` list or `~/.claude/sessions/`. This is inherent to print mode — print mode executes a single prompt and exits; session persistence belongs to interactive sessions only. **Audit trail:** ledger (`progress.md`) + handoff files (`task-N-handoff.json`) + per-task reports (`task-N-report.md`). **Recovery:** re-run the orchestrator shell for that task+mode. **Alternatives considered:** `--session-id` (only targets `--resume`/`--continue`), `--name` (in print mode does not write to session registry), `--background` (long-lived daemon, incompatible with one-shot per-mode dispatch).
+```
+
+- [ ] **Step 2: Verify the doc reads correctly**
+
+```bash
+grep -n 'H6' plugins/superpowers-overrides/docs/sdd-h6-reference.md
+```
+
+Confirm H6.6 appears as item 6 under H6, before H7 begins.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/superpowers-overrides/docs/sdd-h6-reference.md
+git commit -m "docs: add H6.6 session traceability to H6 reference"
+```
+
+---
+
+### Task 2: Add session traceability comment to sdd-run-task-claude.sh
+
+**Files:**
+- Modify: `plugins/superpowers-overrides/bin/sdd-run-task-claude.sh`
+
+**Interfaces:**
+- Consumes: H6.6 rule from Task 1 (referenced via `See H6.6.` pointer)
+
+- [ ] **Step 1: Insert comment after flag invocation line**
+
+In `plugins/superpowers-overrides/bin/sdd-run-task-claude.sh`, locate line 5:
+
+```
+#   claude -p "$prompt" --output-format text --dangerously-skip-permissions
+```
+
+Insert the following line immediately after:
+
+```
+#   Print mode (-p) is one-shot — no session is registered in /resume or
+#   ~/.claude/sessions/. Audit trail is ledger + handoff files, not session
+#   list. See H6.6 in sdd-h6-reference.md.
+```
+
+- [ ] **Step 2: Verify the comment block**
+
+```bash
+head -15 plugins/superpowers-overrides/bin/sdd-run-task-claude.sh
+```
+
+Confirm the new comment appears directly after the flag invocation line and before the `# Do not use --resume` line.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/superpowers-overrides/bin/sdd-run-task-claude.sh
+git commit -m "docs: note print mode session behavior in sdd-run-task-claude.sh"
+```
+
+---
+
+### Task 3: Add session traceability comment to sdd-run-task-cursor.sh
+
+**Files:**
+- Modify: `plugins/superpowers-overrides/bin/sdd-run-task-cursor.sh`
+
+**Interfaces:**
+- Consumes: H6.6 rule from Task 1 (referenced via `See H6.6.` pointer)
+
+- [ ] **Step 1: Insert comment after flag invocation line**
+
+In `plugins/superpowers-overrides/bin/sdd-run-task-cursor.sh`, locate line 5:
+
+```
+#   cursor-agent --print --output-format text --force "$prompt"
+```
+
+Insert the following line immediately after:
+
+```
+#   Print mode (--print) is one-shot — no session is registered in /resume or
+#   ~/.claude/sessions/. Audit trail is ledger + handoff files, not session
+#   list. See H6.6 in sdd-h6-reference.md.
+```
+
+- [ ] **Step 2: Verify the comment block**
+
+```bash
+head -15 plugins/superpowers-overrides/bin/sdd-run-task-cursor.sh
+```
+
+Confirm the new comment appears directly after the flag invocation line and before the `# Do not use --resume` line.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add plugins/superpowers-overrides/bin/sdd-run-task-cursor.sh
+git commit -m "docs: note print mode session behavior in sdd-run-task-cursor.sh"
+```
+
+---
+
+### Task 4: Changeset
+
+**Files:**
+- Create: `.changeset/<auto-generated>.md`
+
+**Interfaces:**
+- Consumes: changes from Tasks 1–3
+
+- [ ] **Step 1: Run changeset**
+
+```bash
+cd plugins/superpowers-overrides && pnpm changeset
+```
+
+Select patch bump for `superpowers-overrides`. Describe: "Document why SDD CLI agents are not traceable via /resume — H6.6 in the reference doc + shell comments."
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .changeset/
+git commit -m "chore: add changeset for session traceability docs"
+```
+

--- a/docs/superpowers/specs/2026-08-07-sdd-gate-shell-consistency-design.md
+++ b/docs/superpowers/specs/2026-08-07-sdd-gate-shell-consistency-design.md
@@ -182,28 +182,27 @@ EOF
 
 ### 测试 fixture 隔离
 
-**约束（实证）**：`git cat-file -e <SHA>` 依赖 CWD 是 git 仓库；非 git 目录会失败。因此 git-object 校验必须用 `git -C "$repo_root" cat-file -e`（绑定 repo_root），且 fixture 根必须是 git 仓库。这排除了「repo_root 参数化 + 嵌套 fixture」方案——fixture 不是 git 仓库时 `cat-file` 找不到对象。正确路径是 `SDD_GATE_FIXTURES_ROOT` env 接缝 + 复制到临时 git 仓库注入 short-SHA。
+**约束（实证）**：
+- `git cat-file -e <SHA>` 依赖 CWD 是 git 仓库；非 git 目录会失败。git-object 校验必须用 `git -C "$repo_root" cat-file -e`（绑定 repo_root）。
+- **`.superpowers` 被根 `.gitignore`（第 4 行，无斜杠 → 匹配任意深度）忽略**；fixture 目录若 `git init` 会变嵌套 git 仓库（`git add` 记成 gitlink，fresh clone 为空）。**因此 fixture 模板不用 `.superpowers/sdd/` 路径、不做 `git init`**——用普通目录 `sdd/` 存放（被跟踪），测试运行时把 `SDD_GATE_FIXTURES_ROOT` 指向临时副本并 `git init` 副本（pending `repo_root` 指向副本，使 `git -C` cat-file 在副本内可解析）。
 
 **fixture 结构**（每个场景独立的 fixture 根，避免 `sdd_find_active_workspace` 首匹配遮蔽）：
 
 ```
 tests/fixtures/sdd-gate/
-  orchestrating/          # 场景根：仅含 orchestrating-ws/
-    .superpowers/sdd/orchestrating-ws/   # 无 TASK_BASE 或无 brief
-  active/                 # 场景根：仅含 active-ws/
-    .superpowers/sdd/active-ws/          # TASK_BASE: <真实 short-SHA>，无 handoff
-  complete/               # 场景根：仅含 complete-ws/
-    .superpowers/sdd/complete-ws/        # TASK_BASE: <真实 SHA> + handoff APPROVED
-  stub/                   # 场景根：仅含 stub-ws/
-    .superpowers/sdd/stub-ws/            # TASK_BASE: abc（stub）—— 断言不激活
+  orchestrating/sdd/orchestrating-ws/      # 空目录（无 brief → 不激活）
+  active/sdd/active-ws/task-1-brief.md     # TASK_BASE: <真实 short-SHA>，无 handoff
+  complete/sdd/complete-ws/
+    task-1-brief.md                        # TASK_BASE: <真实 SHA>
+    task-1-handoff.json                    # status: APPROVED
+  stub/sdd/stub-ws/task-1-brief.md         # TASK_BASE: abc（stub）—— 断言不激活
 ```
 
-每个场景根是独立 git 仓库（`git init`，可指向真实 repo 的对象库或含真实 HEAD 的引用）。
+fixture 模板是**普通目录**（不含 `.git`、不含 `.superpowers`），被 git 正常跟踪。`<真实 short-SHA>` 用占位符 `<SHA>`，测试运行时注入。
 
 **隔离机制**：
-- gate lib 增加 `SDD_GATE_FIXTURES_ROOT`（环境变量）：`sdd_find_active_workspace` / `sdd_gate_phase` 解析 `.superpowers/sdd` 时，若该变量有值则用 `$SDD_GATE_FIXTURES_ROOT` 作为 sdd 根
-- 测试在**临时目录**复制 fixture 场景根（`mktemp -d` + `cp -R`），在副本里注入当前真实 short-SHA（`sed` 替换 `TASK_BASE: <sha>`），再设 `SDD_GATE_FIXTURES_ROOT` 指向副本——**绝不修改被提交的 fixture 文件**（避免 P4 反模式重现）
-- 副本是 git 仓库（`git init` + 至少一个 commit），使 `git -C "$root" cat-file -e <short-sha>` 通过
+- gate lib 增加 `SDD_GATE_FIXTURES_ROOT`（环境变量）：`sdd_find_active_workspace` / `sdd_gate_phase` 解析 sdd 根时，若该变量有值则用 `$SDD_GATE_FIXTURES_ROOT`（签名从 `repo_root` 改为 `sdd_root`，调用点含 `sdd_gate_decide` 单一解析点）
+- 测试在**临时目录**复制 fixture 场景根（`mktemp -d` + `cp -R`），在副本里注入当前真实 short-SHA（`sed` 替换 `TASK_BASE: <SHA>`），`git init` 副本 + 设 pending `repo_root` 指向副本（使 `git -C` cat-file 在副本内可解析），再设 `SDD_GATE_FIXTURES_ROOT` 指向副本的 `sdd/`——**绝不修改被提交的 fixture 文件**（避免 P4 反模式重现）
 
 **现有测试改造**：
 - `override-{claude,cursor}-sdd-gate.test.sh` 改为从 fixture 场景根读取，不再往 `.superpowers/sdd/dogfood-test` 写 stub
@@ -261,7 +260,7 @@ tests/fixtures/sdd-gate/
 | File | Action |
 |------|--------|
 | `bin/lib/sdd-orchestrator-gate.sh` | **Modify** — `sdd_git_verb_allowed` / `sdd_git_object_exists` 新增；`sdd_bash_allowed` **重命名为 `sdd_shell_allowed`** 并扩展（allowlist + 只读 git 动词），唯一调用点在 `sdd_gate_decide` 更新；`sdd_brief_has_task_base` / `sdd_gate_phase` / `sdd_deny_message` 修改；`SDD_GATE_FIXTURES_ROOT` 覆盖 |
-| `tests/fixtures/sdd-gate/` | **Create** — 场景根（orchestrating / active / complete / stub），每场景独立 git 仓库 + `.superpowers/sdd/<ws>/` |
+| `tests/fixtures/sdd-gate/` | **Create** — 场景根（orchestrating / active / complete / stub），普通目录 `sdd/<ws>/`（不含 `.git`/`.superpowers`，被跟踪） |
 | `tests/override-claude-sdd-gate.test.sh` | **Modify** — 从 fixture 读取，删 dogfood-test 依赖 |
 | `tests/override-cursor-sdd-gate.test.sh` | **Modify** — 同上 |
 | `tests/sdd-gate-allow-deny-smoke.sh` | **Create** — 全矩阵 smoke |

--- a/docs/superpowers/specs/2026-08-07-sdd-gate-shell-consistency-design.md
+++ b/docs/superpowers/specs/2026-08-07-sdd-gate-shell-consistency-design.md
@@ -302,14 +302,14 @@ fixture 模板是**普通目录**（不含 `.git`、不含 `.superpowers`），�
 
 | # | Scenario | Pass? | Date |
 |---|----------|-------|------|
-| 1 | 只读 git allow（orchestrating/task_active） | Pending | |
-| 2 | 变更类 git deny | Pending | |
-| 3 | stub-ws 不激活 / active-ws 激活 | Pending | |
-| 4 | bound-ws 不扫描无关 workspace | Pending | |
-| 5 | deny 消息含多行矩阵（git 清单与白名单一致，含 `git show`） | Pending | |
-| 6 | `task_complete` 后 allow | Pending | |
-| 7 | fixture 隔离：测试不碰真实 `.superpowers/sdd/`，临时副本注入 short-SHA | Pending | |
-| 8 | `pnpm run validate` | Pending | |
+| 1 | 只读 git allow（orchestrating/task_active） | ✅ | 2026-08-07 |
+| 2 | 变更类 git deny | ✅ | 2026-08-07 |
+| 3 | stub-ws 不激活 / active-ws 激活 | ✅ | 2026-08-07 |
+| 4 | bound-ws 不扫描无关 workspace | ✅ | 2026-08-07 |
+| 5 | deny 消息含多行矩阵（git 清单与白名单一致，含 `git show`） | ✅ | 2026-08-07 |
+| 6 | `task_complete` 后 allow | ✅ | 2026-08-07 |
+| 7 | fixture 隔离：测试不碰真实 `.superpowers/sdd/`，临时副本注入 short-SHA | ✅ | 2026-08-07 |
+| 8 | `pnpm run validate` | ✅ | 2026-08-07 |
 
 ## Grilling record
 

--- a/docs/superpowers/specs/2026-08-07-sdd-gate-shell-consistency-design.md
+++ b/docs/superpowers/specs/2026-08-07-sdd-gate-shell-consistency-design.md
@@ -243,7 +243,7 @@ fixture 模板是**普通目录**（不含 `.git`、不含 `.superpowers`），�
 | 无 pending / pending 过期 | allow（现状） |
 | `git cat-file -e` 失败（stub SHA 或非 git 根） | workspace 不被视为 active → 不劫持（`git -C "$repo_root" cat-file -e` 绑定仓库根） |
 | `git` 不在 PATH | 保守 deny（`git_object_exists` 返回 1，`git_verb_allowed` 对 git 命令返回 1） |
-| 命令含引号/复杂 token | `sdd_git_verb_allowed` 提取失败 → deny（fail-closed） |
+| verb token 或 branch/remote 参数含引号（如 `git "status"` / `git branch "foo"`） | `sdd_git_verb_allowed` 提取失败 → deny（fail-closed）；参数位置引号（`git status "a b"`、`git log --format="%h"`）按空格拆分，不触发提取失败 → allow |
 | `git -C <path> -c k=v <verb>` | **v1 不在提取范围** → deny（fail-closed，接受行为） |
 | `sdd-workspace` 创建 workspace（orchestrating） | brief 无 TASK_BASE → 不触发 active |
 | 测试 | `SDD_GATE_FIXTURES_ROOT` 覆盖 `.superpowers/sdd` 解析 |

--- a/docs/superpowers/specs/2026-08-07-sdd-gate-shell-consistency-design.md
+++ b/docs/superpowers/specs/2026-08-07-sdd-gate-shell-consistency-design.md
@@ -1,0 +1,326 @@
+# SDD orchestrator gate — Shell/Write 一致性 + 旧 workspace 劫持防护
+
+- **Version**: v1.0 · 2026-08-07
+- **Status**: Draft
+- **Author**: oscaner · Claude Code
+- **Issue**: [Oscaner/skills#53](https://github.com/Oscaner/skills/issues/53)
+- **Program**: SDD Token 效率 (p1-slim 系列) — 独立增量，不挂新的 phase ID
+- **Depends on**: p1-slim.2 gate (`sdd-orchestrator-gate.sh`) @ HEAD
+
+## §0 Incremental warning
+
+> 本 spec 是 **p1-slim.2 PreToolUse gate 的一致性修复 + 防劫持加固**。不改变 H6 four-mode 语义、不改 adapter JSON 格式、不改 fail-open 语义、不改 `task_complete` 的 allow 行为。
+
+## §1 Problem
+
+Dogfood 期间（p1-slim.3、branch-rules、cursor-agent-cli-refactor）orchestrator 在 `TASK_ACTIVE` gate 激活时遭遇不一致的 DX（issue #53 + 三条评论）。实证复现（2026-08-07，本机运行 gate lib）：
+
+| # | 现象 | 根因 | 实证 |
+|---|------|------|------|
+| P1 | Shell vs Write 不对称：workspace 变更走 `Write` 被 allow，同一变更走 shell（heredoc）被 deny；**更糟的是只读 git 诊断（`git status`）也被 deny** | `sdd_gate_decide` 对非白名单 Bash 一律 deny；白名单仅 `sdd-run-task-*`/`sdd-workspace`/`task-brief`/`review-package`/`rev-parse` | `git status --short` 在 orchestrating/task_active 下均 deny |
+| P2 | deny 消息只给「跑 H6」+「允许写 workspace」，不给允许的 Bash 清单 → orchestrator 只能试错 | `sdd_deny_message` 只输出两行，不列 allowlist | 见 §设计 deny 消息 |
+| P3 | 旧/测试 workspace（如 `dogfood-test` 的 `TASK_BASE: abc`）劫持新 session，**整个新计划被挡** | `sdd_find_active_workspace` 扫所有 workspace；`sdd_brief_has_task_base` 只 grep 字符串不验 git 对象；未 bind 时 gate 用扫描结果 | `dogfood-test` 现存 `TASK_BASE: abc` + 无 handoff → 新 minimal session 被挡 |
+| P4 | 测试 fixture 与真实 `.superpowers/sdd/` 混在一起，测试自己制造触发 P3 的 stub | 两个 gate 测试直接往 `dogfood-test` 写 stub | `override-{claude,cursor}-sdd-gate.test.sh` 均写 `dogfood-test` |
+| P5 | issue 评论 3 声称 task_complete 后 shell 仍被挡（缓存） | **误报** — phase 每次从文件系统实时重算，无缓存 | 实证：写 APPROVED handoff 后同一 session 下一调用立即 allow |
+
+**辅助事实**（影响设计）：
+
+- `.superpowers/` 在 `.gitignore`（第 4 行），未被 git 跟踪 → 删除 `dogfood-test` 无提交风险
+- `git cat-file -e abc` 失败、`git cat-file -e <short-sha>` 成功 → git-object 校验可行
+- `TASK_BASE` 由 orchestrator 手工写入真实 `git rev-parse HEAD` SHA（spor-SDD Rule 0a item 4「append `TASK_BASE: <sha>`」），上游 SDD 与 CLI 脚本均不写 → git-object 校验不误伤正常流程
+
+## Goal
+
+让 orchestrator 在 gate 激活时：
+
+1. **只读 git 诊断 Bash 可用、规则透明** — 只读 git 动词放开，deny 消息列出完整 allowlist 矩阵。`ls`/`echo` 等非 git 只读命令**按设计仍 deny**（精简只读集决定，见 Non-goals）
+2. **不被旧 workspace 劫持** — TASK_BASE 必须真实 git object；bound-ws 优先
+3. **有回归测试钉住完整 allow/deny 矩阵** — smoke 测试 + fixture 隔离
+
+## Constraints
+
+- 仅改 `superpowers-overrides` 插件（`bin/`、`tests/`、`docs/`、`skills/`）
+- 不改 adapter JSON 格式（`hookSpecificOutput.permissionDecision` / `.permission`）
+- 不改 H6 four-mode 语义、`sdd-run-task-*.sh` 行为
+- **No duplicated allowlist logic**（p1-slim.2 约束）— 判定逻辑放共享 lib
+- 不改 fail-open 语义（无 jq / 无 pending → allow）
+- spor-SDD 保持 ≤160 行（如动 Rule 0a，需平衡）
+- 不 fork upstream superpowers；不引入 git worktree
+
+## Design
+
+### Architecture
+
+```mermaid
+flowchart TB
+  hook["PreToolUse hook (claude/cursor)"]
+  adapter["adapter (claude/cursor)"]
+  lib["sdd-orchestrator-gate.sh"]
+  shell["sdd_shell_allowed() — 新"]
+  gitverb["sdd_git_verb_allowed() — 新"]
+  object["sdd_git_object_exists() — 新"]
+  phase["sdd_gate_phase() — 改: bound-ws 优先"]
+  brief["sdd_brief_has_task_base() — 改: git-object 校验"]
+  deny["sdd_deny_message() — 改: 多行矩阵"]
+  fixture["tests/fixtures/sdd-gate/ — 新"]
+  smoke["sdd-gate-allow-deny-smoke.sh — 新"]
+
+  hook --> adapter --> lib
+  lib --> shell --> gitverb
+  lib --> phase --> brief --> object
+  lib --> deny
+  smoke --> fixture
+  smoke --> lib
+```
+
+### 核心判定 — `sdd_shell_allowed()`（重命名自 `sdd_bash_allowed`，共享单源）
+
+现有 `sdd_bash_allowed` 重命名为 `sdd_shell_allowed` 并扩展：allowlist（保留）之上增加只读 git 动词判定。唯一调用点在 `sdd_gate_decide`（shell 分支），不保留两个函数（避免重复 allowlist 逻辑）。
+
+**匹配优先级**（先 allowlist，再只读 git 动词，其余 deny）：
+
+```bash
+# 1. allowlist 脚本（现状保留）
+case "$cmd" in
+  *sdd-run-task-*|*sdd-workspace*|*task-brief*|*review-package*) return 0 ;;
+esac
+# 2. 只读 git 动词（新）
+if sdd_git_verb_allowed "$cmd"; then return 0; fi
+# 3. 其余 → deny
+return 1
+```
+
+**`sdd_git_verb_allowed()`** 负责提取 git 子命令并查白名单（提取逻辑**归属该函数内部**，无独立 `parse_git_verb` 函数）。提取边界固定：
+
+```
+command 形如:
+  git <verb> ...                    → verb = $2
+  git -C <path> <verb> ...          → 跳过 -C 及其路径
+  git --git-dir=<path> <verb> ...   → 跳过 --git-dir=<path>
+提取到 <verb> 后查白名单；提取失败 → return 1（deny，fail-closed）。
+```
+
+**v1 明确不在提取范围**：`git -C <path> -c k=v <verb>`（带 `-c` 配置选项）——提取失败 → deny（fail-closed，接受行为）。如需支持在后续版本加（不设 AC）。
+
+**只读白名单（精简集）**：
+`status diff log show rev-parse branch remote ls-files diff-tree`
+
+**明确排除（变更类，仍 deny）**：`add commit push pull reset checkout clean stash merge rebase cherry-pick restore switch rm mv` 及一切非白名单动词。
+
+**实现位置**：`sdd-orchestrator-gate.sh`（共享 lib）→ 两个 harness adapter 自动继承，无重复逻辑。
+
+**解析失败 → deny（fail-closed）**。`git` 不在 PATH → `sdd_git_object_exists` 返回 1（保守），`sdd_git_verb_allowed` 对 git 命令返回 1（deny，保守）。
+
+### 防劫持双保险
+
+**保险 1 — `sdd_brief_has_task_base()` 加 git-object 校验**：
+
+```bash
+# 传入 repo_root：git cat-file 必须绑定仓库根（CWD 无关）
+# 实证：bare `git cat-file -e` 依赖 CWD 是 git 仓库；`git -C <repo>` 从任意 CWD 可用
+sdd_git_object_exists() {
+  local repo_root="$1" sha="$2"
+  git -C "$repo_root" cat-file -e "$sha" 2>/dev/null   # 真实 SHA → 0；stub 'abc' → 1
+}
+
+sdd_brief_has_task_base() {
+  local brief="$1" repo_root="$2"
+  [[ -f "$brief" ]] || return 1
+  local sha
+  sha="$(sed -nE 's/^TASK_BASE: //p' "$brief" | head -1 | tr -d ' \r')"
+  [[ -n "$sha" ]] || return 1
+  sdd_git_object_exists "$repo_root" "$sha"
+}
+```
+
+> 已验证：`git cat-file -e abc` 失败、`git cat-file -e <short-sha>` 成功；`git -C <repo> cat-file -e <sha>` 从任意 CWD 可用（非 git 目录 bare 调用失败）。短 SHA 也通过（`git cat-file -e` 接受缩写）。正常流程写入真实 `git rev-parse HEAD` SHA，不误伤。
+
+调用链传播：`sdd_find_active_workspace` / `sdd_gate_phase` 已有 `repo_root`，把 `$repo_root` 传给 `sdd_brief_has_task_base "$brief" "$repo_root"`。
+
+**保险 2 — `sdd_gate_phase()` 优先 bound workspace**：
+
+`active_ws` 的**单一解析点**在 `sdd_gate_decide`：`active_ws = sdd_resolve_workspace ?? sdd_find_active_workspace`（bound 优先，minimal 才扫描）。解析结果**线程化**传入 `sdd_gate_phase` 与 `sdd_write_allowed` 两个调用——两者使用**同一个** `active_ws`，不再各自 resolve/find（当前 `sdd_gate_phase` 内部重复 resolve/find 是分叉来源）。
+
+```bash
+# sdd_gate_decide 内（单次解析）
+active_ws="$(sdd_resolve_workspace "$repo_root" "$pending" || true)"
+if [[ -z "$active_ws" ]]; then
+  active_ws="$(sdd_find_active_workspace "$repo_root" || true)"   # git-object 过滤后 stub 不激活
+fi
+phase="$(sdd_gate_phase "$repo_root" "$active_ws" "$pending")"   # 传入已解析 active_ws
+# ... write 判定同样传 $active_ws
+```
+
+`sdd_gate_phase` 接收已解析的 `$workspace`，**不再内部重复 resolve/find**。`task_complete` 判定依赖「APPROVED handoff + 无 next brief」，必须基于这个单一 `active_ws`。
+
+### deny 消息 — 多行 allowlist 矩阵
+
+```bash
+sdd_deny_message() {
+  cat <<EOF
+SDD orchestrator gate — direct repo edits forbidden during active task.
+
+Allowed Bash (read-only diagnostics):
+  git status / git diff / git log / git show / git rev-parse / git branch / git remote
+  git ls-files / git diff-tree
+  {plugin_root}/bin/sdd-run-task-<harness>.sh
+  sdd-workspace / task-brief / review-package
+
+Allowed Write:
+  .superpowers/sdd/<plan-basename>/
+
+Repo changes flow only through:
+  {plugin_root}/bin/sdd-run-task-<harness>.sh --task N --mode implement
+
+Full matrix: docs/sdd-h6-reference.md (SDD gate matrix)
+See spor-SDD Rule 0a item 4.
+EOF
+}
+```
+
+`<plan-basename>` 由 `sdd_plan_basename()` 算出；`<harness>` 已传入。
+
+### 测试 fixture 隔离
+
+**约束（实证）**：`git cat-file -e <SHA>` 依赖 CWD 是 git 仓库；非 git 目录会失败。因此 git-object 校验必须用 `git -C "$repo_root" cat-file -e`（绑定 repo_root），且 fixture 根必须是 git 仓库。这排除了「repo_root 参数化 + 嵌套 fixture」方案——fixture 不是 git 仓库时 `cat-file` 找不到对象。正确路径是 `SDD_GATE_FIXTURES_ROOT` env 接缝 + 复制到临时 git 仓库注入 short-SHA。
+
+**fixture 结构**（每个场景独立的 fixture 根，避免 `sdd_find_active_workspace` 首匹配遮蔽）：
+
+```
+tests/fixtures/sdd-gate/
+  orchestrating/          # 场景根：仅含 orchestrating-ws/
+    .superpowers/sdd/orchestrating-ws/   # 无 TASK_BASE 或无 brief
+  active/                 # 场景根：仅含 active-ws/
+    .superpowers/sdd/active-ws/          # TASK_BASE: <真实 short-SHA>，无 handoff
+  complete/               # 场景根：仅含 complete-ws/
+    .superpowers/sdd/complete-ws/        # TASK_BASE: <真实 SHA> + handoff APPROVED
+  stub/                   # 场景根：仅含 stub-ws/
+    .superpowers/sdd/stub-ws/            # TASK_BASE: abc（stub）—— 断言不激活
+```
+
+每个场景根是独立 git 仓库（`git init`，可指向真实 repo 的对象库或含真实 HEAD 的引用）。
+
+**隔离机制**：
+- gate lib 增加 `SDD_GATE_FIXTURES_ROOT`（环境变量）：`sdd_find_active_workspace` / `sdd_gate_phase` 解析 `.superpowers/sdd` 时，若该变量有值则用 `$SDD_GATE_FIXTURES_ROOT` 作为 sdd 根
+- 测试在**临时目录**复制 fixture 场景根（`mktemp -d` + `cp -R`），在副本里注入当前真实 short-SHA（`sed` 替换 `TASK_BASE: <sha>`），再设 `SDD_GATE_FIXTURES_ROOT` 指向副本——**绝不修改被提交的 fixture 文件**（避免 P4 反模式重现）
+- 副本是 git 仓库（`git init` + 至少一个 commit），使 `git -C "$root" cat-file -e <short-sha>` 通过
+
+**现有测试改造**：
+- `override-{claude,cursor}-sdd-gate.test.sh` 改为从 fixture 场景根读取，不再往 `.superpowers/sdd/dogfood-test` 写 stub
+- 每个测试用其场景根设 `SDD_GATE_FIXTURES_ROOT`，用 `sdd-session-activate.sh bind` 把 pending 指向 fixture 根
+- 删除 `dogfood-test`（`.gitignore` 已忽略，无提交风险）
+
+### 数据流与判定矩阵（改动后）
+
+```
+工具调用 → hook → adapter → sdd_gate_decide()
+  1. 无 jq / 无 pending → allow（fail-open）
+  2. pending 过期(>24h) → 清 pending → allow
+  3. active_ws = sdd_resolve_workspace(repo_root, pending) ?? sdd_find_active_workspace(repo_root)   # 单一解析点
+     phase = sdd_gate_phase(repo_root, active_ws, pending)
+  4. Shell → sdd_shell_allowed(cmd)
+     Write → sdd_write_allowed(abs_path, repo_root, active_ws, phase)
+     else  → allow
+  5. deny → sdd_deny_message()
+```
+
+| 工具 | 条件 | 判定 |
+|------|------|------|
+| Write/Edit | 路径在 `active_ws` 下 | **allow** |
+| Write/Edit | 路径在 `.superpowers/sdd/**` 且 phase=orchestrating | **allow** |
+| Write/Edit | phase=inactive/task_complete | **allow**（现状保留，`sdd_write_allowed` line 251） |
+| Write/Edit | 其它仓库路径 | **deny** |
+| Bash/Shell | allowlist（sdd-*/workspace/task-brief/review-package） | **allow** |
+| Bash/Shell | 只读 git 动词（白名单） | **allow** |
+| Bash/Shell | 其它（变更类 git、`ls`、heredoc 写文件） | **deny** |
+| Bash/Shell | phase=inactive/task_complete | **allow**（现状保留） |
+| 其它工具 | — | allow |
+
+### 错误处理
+
+| 场景 | 行为 |
+|------|------|
+| 无 `jq` | fail-open → allow（现状） |
+| 无 pending / pending 过期 | allow（现状） |
+| `git cat-file -e` 失败（stub SHA 或非 git 根） | workspace 不被视为 active → 不劫持（`git -C "$repo_root" cat-file -e` 绑定仓库根） |
+| `git` 不在 PATH | 保守 deny（`git_object_exists` 返回 1，`git_verb_allowed` 对 git 命令返回 1） |
+| 命令含引号/复杂 token | `sdd_git_verb_allowed` 提取失败 → deny（fail-closed） |
+| `git -C <path> -c k=v <verb>` | **v1 不在提取范围** → deny（fail-closed，接受行为） |
+| `sdd-workspace` 创建 workspace（orchestrating） | brief 无 TASK_BASE → 不触发 active |
+| 测试 | `SDD_GATE_FIXTURES_ROOT` 覆盖 `.superpowers/sdd` 解析 |
+
+### 安全属性（fail-closed）
+
+1. 任何解析失败 → deny（不是 allow）
+2. `git` 缺失 → 保守 deny
+3. 只读集以外的 git 动词、所有非 git 命令 → deny
+4. `git` 白名单只放行查询类：`status/diff/log/show/rev-parse/branch/remote/ls-files/diff-tree`
+
+## File map
+
+| File | Action |
+|------|--------|
+| `bin/lib/sdd-orchestrator-gate.sh` | **Modify** — `sdd_git_verb_allowed` / `sdd_git_object_exists` 新增；`sdd_bash_allowed` **重命名为 `sdd_shell_allowed`** 并扩展（allowlist + 只读 git 动词），唯一调用点在 `sdd_gate_decide` 更新；`sdd_brief_has_task_base` / `sdd_gate_phase` / `sdd_deny_message` 修改；`SDD_GATE_FIXTURES_ROOT` 覆盖 |
+| `tests/fixtures/sdd-gate/` | **Create** — 场景根（orchestrating / active / complete / stub），每场景独立 git 仓库 + `.superpowers/sdd/<ws>/` |
+| `tests/override-claude-sdd-gate.test.sh` | **Modify** — 从 fixture 读取，删 dogfood-test 依赖 |
+| `tests/override-cursor-sdd-gate.test.sh` | **Modify** — 同上 |
+| `tests/sdd-gate-allow-deny-smoke.sh` | **Create** — 全矩阵 smoke |
+| `scripts/ci-validate.sh` / `tests/validate-overrides-build.sh` | **Modify** — 挂载 smoke |
+| `docs/sdd-h6-reference.md` | **Modify** — 新增 `## SDD gate matrix` 小节 |
+| `docs/cross-harness-overrides.md` | **Modify** — 同步 gate 文档（只读 git、deny 消息矩阵） |
+| `skills/spor-subagent-driven-development/SKILL.md` | **Modify** — Rule 0a 补「只读 git 可用 + TASK_BASE 必须真实 SHA」（保持 ≤160 行） |
+| `.superpowers/sdd/dogfood-test/` | **Delete** — gitignored，无提交风险 |
+
+## Acceptance criteria
+
+1. `sdd_git_verb_allowed` 对 `git status` / `git -C x status` / `git --git-dir=x status` / `git diff HEAD~1` 提取正确；`git -C x -c k=v status` **deny**（v1 超出范围）
+2. 只读 git 在 `orchestrating`/`task_active` 下 **allow**；变更类 git（`git add`/`git commit`/`git push`）**deny**
+3. `TASK_BASE: abc` 的 stub-ws **不**激活；真实 SHA 的 active-ws 正常激活
+4. bound-ws 存在时 gate 不扫描无关 workspace（不被 `dogfood-test` 或 stub 劫持）；phase 判定与 write 判定使用**同一个** `active_ws`（单一解析点线程化）
+5. deny 消息包含多行 allowlist 矩阵，只读 git 清单与白名单一致（**含 `git show`**）
+6. `task_complete` 后 shell/Write allow（回归评论 3 误报）
+7. 两个现有 gate 测试改造后仍通过（从 fixture 场景根读取，`SDD_GATE_FIXTURES_ROOT` + 临时副本注入 short-SHA，不修改被提交 fixture）；新 smoke 通过
+8. `pnpm run validate` exit 0
+9. `.superpowers/sdd/` 不再被测试写 stub；`dogfood-test` 已删除
+10. adapter JSON 格式不变；H6 four-mode 语义不变；fail-open 语义不变
+
+## §3 Deviations from overall
+
+| Overall assumption | Phase decision | Overall updated? |
+|---|---|---|
+| p1-slim.2 gate 一致性 | issue #53 独立增量修复，不挂新 phase ID | **No** — 独立 issue，非 program phase |
+
+## Non-goals
+
+- 改 adapter JSON 格式
+- 改 H6 four-mode 语义 / `sdd-run-task-*.sh` 行为
+- 改 fail-open 语义
+- 改 `task_complete` 的 allow 行为
+- 放开 `ls`/`echo` 等非 git 只读命令（精简只读集决定）
+- 解决 issue #53 评论 3 的「缓存」（实证为误报，无缓存）
+
+## §Smoke results
+
+| # | Scenario | Pass? | Date |
+|---|----------|-------|------|
+| 1 | 只读 git allow（orchestrating/task_active） | Pending | |
+| 2 | 变更类 git deny | Pending | |
+| 3 | stub-ws 不激活 / active-ws 激活 | Pending | |
+| 4 | bound-ws 不扫描无关 workspace | Pending | |
+| 5 | deny 消息含多行矩阵（git 清单与白名单一致，含 `git show`） | Pending | |
+| 6 | `task_complete` 后 allow | Pending | |
+| 7 | fixture 隔离：测试不碰真实 `.superpowers/sdd/`，临时副本注入 short-SHA | Pending | |
+| 8 | `pnpm run validate` | Pending | |
+
+## Grilling record
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 1 | 范围 | Full sweep — (a) Bash 一致性 + deny 矩阵 + 文档; (b) 防劫持; (c) smoke |
+| 2 | Bash 策略 | 安全 git 动词白名单（精简只读集 ~9 个） |
+| 3 | 劫持防护 | git-object 校验 + bound-ws 优先（双保险） |
+| 4 | 测试 fixture | 隔离到 `tests/fixtures/sdd-gate/` + `SDD_GATE_FIXTURES_ROOT` |
+| 5 | deny 消息 | 多行 allowlist 矩阵 |
+| 6 | git 动词集 | 精简只读集（status/diff/log/show/rev-parse/branch/remote/ls-files/diff-tree） |
+
+User design approval: 2026-08-07（§1–§5 逐节「OK，继续」，最终「批准，写 spec」）。

--- a/docs/superpowers/specs/2026-08-07-sdd-session-traceability-design.md
+++ b/docs/superpowers/specs/2026-08-07-sdd-session-traceability-design.md
@@ -1,0 +1,61 @@
+# H6 CLI Agent Session Traceability
+
+**Date:** 2026-08-07
+**Issue:** https://github.com/Oscaner/skills/issues/79
+**Status:** approved
+
+## Problem
+
+SDD CLI agents (`sdd-run-task-claude.sh`, `sdd-run-task-cursor.sh`) invoke the harness in one-shot print mode (`-p` / `--print` / `--output-format text`). Print mode does not register sessions in the `/resume` list or `~/.claude/sessions/`. The orchestrator and user cannot locate which session executed Task N's implement, nor inspect/recover a task's execution context via the session picker.
+
+H6.5 already forbids `--resume` (ensuring clean context per invocation). The gap is that there is no way at all to see these executions in the session system — not about reusing context, just about visibility.
+
+## Root Cause
+
+This is inherent to print mode, not a missing flag:
+
+- `~/.claude/sessions/` only contains records with `"kind": "interactive"` — print mode is not interactive
+- `--session-id` only targets `--resume`/`--continue` (specify which session to resume), not print mode
+- `--name` in print mode does not write to the session registry
+- `--no-session-persistence` docs state "(only works with --print)" — print mode never persisted sessions in the `/resume` sense
+- `--background` starts a long-lived daemon, incompatible with one-shot per-mode dispatch
+
+Verified via local testing (2026-08-07, Claude Code v2.1.224) and web search — no workaround exists.
+
+## Solution
+
+Document the behavior. No code changes.
+
+### Files changed
+
+| File | Change |
+|---|---|
+| `plugins/superpowers-overrides/docs/sdd-h6-reference.md` | New H6.6 section: session traceability explanation, implications, alternatives-considered |
+| `plugins/superpowers-overrides/bin/sdd-run-task-claude.sh` | Top comment block: note that print mode creates no session, point to H6.6 |
+| `plugins/superpowers-overrides/bin/sdd-run-task-cursor.sh` | Same comment update |
+
+### Shell comment update
+
+Insert after the flag invocation comment in each script (line 5 of the top comment block in both scripts):
+
+**sdd-run-task-claude.sh:**
+> Print mode (-p) is one-shot — no session is registered in /resume or ~/.claude/sessions/. Audit trail is ledger + handoff files, not session list. See H6.6.
+
+**sdd-run-task-cursor.sh:**
+> Print mode (--print) is one-shot — no session is registered in /resume or ~/.claude/sessions/. Audit trail is ledger + handoff files, not session list. See H6.6.
+
+### Non-changes
+
+- No shell execution logic changed (the `claude -p "$prompt"` / `cursor-agent --print ...` invocation lines stay as-is)
+- No flags added to `claude -p` or `cursor-agent --print`
+- H6.5 forbidden list unchanged
+
+### H6.6 format
+
+Match existing doc's numbered-rule style under H6:
+
+> 6. **Session traceability:** CLI agents use one-shot print mode (`--print` / `--output-format text`), which does NOT register sessions in the `/resume` list or `~/.claude/sessions/`. This is inherent to print mode — print mode executes a single prompt and exits; session persistence belongs to interactive sessions only. **Audit trail:** ledger (`progress.md`) + handoff files (`task-N-handoff.json`) + per-task reports (`task-N-report.md`). **Recovery:** re-run the orchestrator shell for that task+mode. **Alternatives considered:** `--session-id` (only targets `--resume`/`--continue`), `--name` (in print mode does not write to session registry), `--background` (long-lived daemon, incompatible with one-shot per-mode dispatch).
+
+### Related
+
+- Issue #53 (gate consistency) — same family of dogfood DX improvements

--- a/docs/superpowers/tickets/2026-08-07-sdd-gate-shell-consistency-tickets.md
+++ b/docs/superpowers/tickets/2026-08-07-sdd-gate-shell-consistency-tickets.md
@@ -1,0 +1,74 @@
+# Tickets: SDD gate Shell/Write 一致性 + 防劫持
+
+修复 SDD PreToolUse gate 的 Shell/Write 不对称（issue #53）并加固防劫持：只读 git 诊断 Bash 可用 + deny 消息矩阵；TASK_BASE 必须真实 git object + bound-ws 优先；全矩阵 smoke + fixture 隔离。源 spec/plan：[spec](../specs/2026-08-07-sdd-gate-shell-consistency-design.md) · [plan](../plans/2026-08-07-sdd-gate-shell-consistency.md)。
+
+Work the **frontier**: any ticket whose blockers are all done. 串行依赖：T0 → T3/T4/T5/T6 上游链。
+
+## T0 — 建 gate 测试 fixture 基础
+
+**What to build:** 一套可被 gate 测试复用的隔离 fixture 场景（orchestrating / active / complete / stub），每个场景是可独立起作用的 SDD workspace 模板，供后续测试驱动 gate 的各个状态。
+
+**Blocked by:** None — can start immediately.
+
+- [ ] 创建 fixture 目录树（普通目录，不含 `.git`/`.superpowers`，被 git 跟踪）
+- [ ] 每个场景含正确的 brief/handoff 模板（active 无 handoff、complete 含 APPROVED、stub 用 `abc`）
+
+## T1 — gate 允许只读 git 诊断
+
+**What to build:** orchestrator 在 gate 激活时能运行只读 git 诊断命令（`git status`/`git diff`/`git log` 等白名单动词），变更类 git 命令仍被拒；被拒时的提示消息升级为完整 allowlist 矩阵，规则一眼可见。
+
+**Blocked by:** None — can start immediately.
+
+- [ ] 只读 git 动词白名单放行，变更类 deny
+- [ ] deny 消息含多行 allowlist 矩阵（含 `git show`）
+- [ ] 提取失败一律 deny（fail-closed）
+
+## T2 — 阻止旧 workspace 劫持
+
+**What to build:** 一个遗留的测试/陈旧 SDD workspace 不再能劫持新 session：`TASK_BASE` 必须指向真实 git 对象才激活；session 绑定 workspace 后 gate 只认该 workspace，不扫描无关目录。
+
+**Blocked by:** None — can start immediately.
+
+- [ ] `TASK_BASE` 非真实 git 对象的 workspace 不激活
+- [ ] 绑定 workspace 后不扫描无关目录
+- [ ] phase 判定与 write 判定用同一个 workspace（单一解析点）
+
+## T3 — 测试切换到隔离 fixture
+
+**What to build:** 两个现有 gate 测试不再往真实 workspace 树写 stub，改为从隔离 fixture 驱动；gate 支持测试环境的 sdd 根覆盖，真实 `.superpowers/sdd/` 保持干净。
+
+**Blocked by:** T0, T1, T2
+
+- [ ] gate 支持 sdd 根覆盖（env seam）
+- [ ] claude + cursor 测试从 fixture 驱动，删除 dogfood-test 依赖
+- [ ] 测试验证不污染真实 workspace 树
+
+## T4 — 全矩阵 smoke + CI
+
+**What to build:** 一个断言完整 allow/deny 矩阵的 smoke 测试（每行一断言），并挂进 CI，任何未来 gate 行为回归都会在 CI 上失败。
+
+**Blocked by:** T1, T2, T3
+
+- [ ] smoke 覆盖判定矩阵每行 + AC1 边界用例
+- [ ] 挂载到 CI
+- [ ] 手动运行通过
+
+## T5 — 文档同步 gate 矩阵
+
+**What to build:** orchestrator 可查阅的完整 gate 规则文档：允许/拒绝矩阵、Shell 契约、防劫持说明；spor-SDD 清单补一行同步。
+
+**Blocked by:** T1, T2
+
+- [ ] 参考文档含完整 gate 矩阵
+- [ ] cross-harness 文档同步
+- [ ] spor-SDD 清单补只读 git + TASK_BASE 说明（保持 ≤160 行）
+
+## T6 — 清理与全量验证
+
+**What to build:** 删除遗留的测试 stub workspace，全量验证通过，spec 记录实际 smoke 结果。
+
+**Blocked by:** T1, T2, T3, T4, T5
+
+- [ ] 删除遗留 stub workspace
+- [ ] `pnpm run validate` 全绿
+- [ ] spec §Smoke 记录实际结果

--- a/docs/superpowers/tickets/2026-08-07-sdd-session-traceability-tickets.md
+++ b/docs/superpowers/tickets/2026-08-07-sdd-session-traceability-tickets.md
@@ -1,0 +1,58 @@
+# 2026-08-07-sdd-session-traceability-tickets
+
+> Parent plan: `../plans/2026-08-07-sdd-session-traceability.md`
+> Issue: https://github.com/Oscaner/skills/issues/79
+
+| # | Title | Blocked by | Plan tasks covered | Demo |
+|---|---|---|---|---|
+| T0 | Add H6.6 session traceability to H6 reference | None — can start immediately | Task 1 | `grep -A2 'H6.6' plugins/superpowers-overrides/docs/sdd-h6-reference.md` 输出新规则 |
+| T1 | Add session traceability comment to sdd-run-task-claude.sh | T0 | Task 2 | `head -15 plugins/superpowers-overrides/bin/sdd-run-task-claude.sh` 显示注释 |
+| T2 | Add session traceability comment to sdd-run-task-cursor.sh | T0 | Task 3 | `head -15 plugins/superpowers-overrides/bin/sdd-run-task-cursor.sh` 显示注释 |
+| T3 | Changeset | T0, T1, T2 | Task 4 | `pnpm run validate` 通过 |
+
+## T0 — Add H6.6 session traceability to H6 reference
+
+**What to build:** 在 H6 参考文档 H6.5 后新增 H6.6，解释 CLI agent 为什么不在 `/resume` 列表中可见。
+
+**Blocked by:** None — can start immediately
+
+**Status:** ready-for-agent
+
+- [ ] `plugins/superpowers-overrides/docs/sdd-h6-reference.md` 中在 H6.5 行后插入 H6.6 文本
+- [ ] H6.6 格式与现有 numbered-rule 风格一致
+- [ ] commit: `docs: add H6.6 session traceability to H6 reference`
+
+## T1 — Add session traceability comment to sdd-run-task-claude.sh
+
+**What to build:** 在 Claude shell 脚本顶部注释中加入 session 不可追踪的说明，指向 H6.6。
+
+**Blocked by:** T0（需要 H6.6 存在才能引用）
+
+**Status:** ready-for-agent
+
+- [ ] 在 line 5（flag invocation comment）后插入提示注释
+- [ ] 注释使用 `-p`（Claude 的短 flag）
+- [ ] commit: `docs: note print mode session behavior in sdd-run-task-claude.sh`
+
+## T2 — Add session traceability comment to sdd-run-task-cursor.sh
+
+**What to build:** 在 Cursor shell 脚本顶部注释中加入 session 不可追踪的说明，指向 H6.6。
+
+**Blocked by:** T0（需要 H6.6 存在才能引用）
+
+**Status:** ready-for-agent
+
+- [ ] 在 line 5（flag invocation comment）后插入提示注释
+- [ ] 注释使用 `--print`（Cursor 的长 flag）
+- [ ] commit: `docs: note print mode session behavior in sdd-run-task-cursor.sh`
+
+## T3 — Changeset
+
+**What to build:** 运行 `pnpm changeset` 记录 patch bump。
+
+**Blocked by:** T0, T1, T2（所有文档变更完成后才能 bump 版本）
+
+**Status:** ready-for-agent
+
+- [ ] `cd plugins/superpowers-overrides && pnpm changeset`（或从 repo root `pnpm changeset`），选 patch，描述文档变更
+- [ ] commit: `chore: add changeset for session traceability docs`

--- a/plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh
+++ b/plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh
@@ -298,6 +298,7 @@ ${verbs}
 	Repo changes flow only through:
 	  ${plugin_root}/bin/sdd-run-task-${harness}.sh --task ${task_num} --mode implement
 
+	Full matrix: docs/sdd-h6-reference.md (SDD gate matrix)
 	See spor-SDD Rule 0a item 4.
 	EOF
 }

--- a/plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh
+++ b/plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh
@@ -100,7 +100,7 @@ sdd_git_verb_allowed() {
   local cmd="$1" verb="" i
   local -a tokens=()
   case "$cmd" in
-    *"&&"*|*"|"*|*";"*|*">"*|*"<"*|*"\$("*|*"\`"*|*$'\n'*) return 1 ;;
+    *"&&"*|*"&"*|*"|"*|*";"*|*">"*|*"<"*|*"\$("*|*"\`"*|*$'\n'*) return 1 ;;
   esac
   read -r -a tokens <<<"$cmd"
   [[ "${tokens[0]:-}" == "git" ]] || return 1

--- a/plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh
+++ b/plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh
@@ -176,6 +176,12 @@ sdd_resolve_workspace() {
   return 1
 }
 
+# git cat-file 必须绑定 repo_root（CWD 无关）。实证：bare `git cat-file -e` 依赖 CWD 是 git 仓库。
+sdd_git_object_exists() {
+  local repo_root="$1" sha="$2"
+  git -C "$repo_root" cat-file -e "$sha" 2>/dev/null
+}
+
 sdd_find_active_workspace() {
   local repo_root="$1"
   local sdd_root="$repo_root/.superpowers/sdd" dir brief n handoff
@@ -186,7 +192,7 @@ sdd_find_active_workspace() {
     while [[ -f "${dir}task-${n}-brief.md" ]]; do
       brief="${dir}task-${n}-brief.md"
       handoff="${dir}task-${n}-handoff.json"
-      if sdd_brief_has_task_base "$brief" && ! sdd_handoff_approved "$handoff"; then
+      if sdd_brief_has_task_base "$brief" "$repo_root" && ! sdd_handoff_approved "$handoff"; then
         printf '%s\n' "${dir%/}"
         return 0
       fi
@@ -197,7 +203,12 @@ sdd_find_active_workspace() {
 }
 
 sdd_brief_has_task_base() {
-  [[ -f "$1" ]] && grep -qE '^TASK_BASE: ' "$1" 2>/dev/null
+  local brief="$1" repo_root="$2"
+  [[ -f "$brief" ]] || return 1
+  local sha
+  sha="$(sed -nE 's/^TASK_BASE: //p' "$brief" | head -1 | tr -d ' \r')"
+  [[ -n "$sha" ]] || return 1
+  sdd_git_object_exists "$repo_root" "$sha"
 }
 
 sdd_handoff_approved() {
@@ -208,7 +219,7 @@ sdd_handoff_approved() {
 }
 
 sdd_frontier_task() {
-  local workspace="$1" n=1 brief handoff
+  local workspace="$1" repo_root="$2" n=1 brief handoff
   while [[ -n "$workspace" ]]; do
     brief="${workspace}/task-${n}-brief.md"
     handoff="${workspace}/task-${n}-handoff.json"
@@ -216,7 +227,7 @@ sdd_frontier_task() {
       printf '%s\n' "$((n - 1))"
       return 0
     fi
-    if sdd_brief_has_task_base "$brief"; then
+    if sdd_brief_has_task_base "$brief" "$repo_root"; then
       if ! sdd_handoff_approved "$handoff"; then
         printf '%s\n' "$n"
         return 0
@@ -235,28 +246,25 @@ sdd_gate_phase() {
   local n brief next_brief active_ws
   active_ws="$workspace"
   if [[ -z "$active_ws" ]]; then
-    active_ws="$(sdd_find_active_workspace "$repo_root" || true)"
-  fi
-  if [[ -z "$active_ws" ]]; then
     printf 'orchestrating\n'
     return 0
   fi
-  n="$(sdd_frontier_task "$active_ws")"
+  n="$(sdd_frontier_task "$active_ws" "$repo_root")"
   brief="${active_ws}/task-${n}-brief.md"
   next_brief="${active_ws}/task-$((n + 1))-brief.md"
   if [[ "$n" -eq 0 ]]; then
     printf 'orchestrating\n'
     return 0
   fi
-  if sdd_brief_has_task_base "$brief" && ! sdd_handoff_approved "${active_ws}/task-${n}-handoff.json"; then
+  if sdd_brief_has_task_base "$brief" "$repo_root" && ! sdd_handoff_approved "${active_ws}/task-${n}-handoff.json"; then
     printf 'task_active\n'
     return 0
   fi
-  if sdd_handoff_approved "${active_ws}/task-${n}-handoff.json" && ! sdd_brief_has_task_base "$next_brief"; then
+  if sdd_handoff_approved "${active_ws}/task-${n}-handoff.json" && ! sdd_brief_has_task_base "$next_brief" "$repo_root"; then
     printf 'task_complete\n'
     return 0
   fi
-  if sdd_brief_has_task_base "$brief"; then
+  if sdd_brief_has_task_base "$brief" "$repo_root"; then
     printf 'task_active\n'
     return 0
   fi
@@ -264,8 +272,8 @@ sdd_gate_phase() {
 }
 
 sdd_active_task_num() {
-  local workspace="$1"
-  sdd_frontier_task "$workspace"
+  local workspace="$1" repo_root="$2"
+  sdd_frontier_task "$workspace" "$repo_root"
 }
 
 sdd_deny_message() {
@@ -363,7 +371,7 @@ sdd_gate_decide() {
   if [[ -z "$active_ws" ]]; then
     active_ws="$(sdd_find_active_workspace "$repo_root" || true)"
   fi
-  phase="$(sdd_gate_phase "$repo_root" "$workspace" "$pending")"
+  phase="$(sdd_gate_phase "$repo_root" "$active_ws" "$pending")"
 
   if sdd_is_shell_tool "$tool_name"; then
     cmd="$(sdd_extract_command "$tool_input_json")"
@@ -375,7 +383,7 @@ sdd_gate_decide() {
       printf 'allow\n'
       return 0
     fi
-    task_num="$(sdd_active_task_num "$active_ws")"
+    task_num="$(sdd_active_task_num "$active_ws" "$repo_root")"
     [[ "$task_num" -gt 0 ]] || task_num=1
     plan_base="$(sdd_plan_basename "$active_ws" "$pending")"
     msg="$(sdd_deny_message "$harness" "$task_num" "$plan_base")"
@@ -391,7 +399,7 @@ sdd_gate_decide() {
       printf 'allow\n'
       return 0
     fi
-    task_num="$(sdd_active_task_num "$active_ws")"
+    task_num="$(sdd_active_task_num "$active_ws" "$repo_root")"
     [[ "$task_num" -gt 0 ]] || task_num=1
     plan_base="$(sdd_plan_basename "$active_ws" "$pending")"
     msg="$(sdd_deny_message "$harness" "$task_num" "$plan_base")"

--- a/plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh
+++ b/plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh
@@ -74,6 +74,11 @@ sdd_extract_command() {
   printf '%s' "$tool_input_json" | jq -r '.command // empty'
 }
 
+# 只读 git 动词白名单 — 单源（判定 + deny 消息矩阵共用）。
+sdd_readonly_git_verbs() {
+  printf '%s\n' "status diff log show rev-parse branch remote ls-files diff-tree"
+}
+
 sdd_shell_allowed() {
   local cmd="$1"
   case "$cmd" in
@@ -88,12 +93,18 @@ sdd_shell_allowed() {
 # 提取 git 子命令并查只读白名单。提取失败 → return 1（deny，fail-closed）。
 # 支持：git <verb>、git -C <path> <verb>、git --git-dir=<path> <verb>
 # v1 不支持：git -C <path> -c k=v <verb>（-c 配置选项）→ 提取失败 → deny
+# 含 shell 操作符（&& | ; > < $( ` 换行）或多行命令 → deny（防复合命令绕过）。
+# branch/remote 只放行只读子参数（-a -r -v --show-current），拒绝变更类
+# （-d -D -m 及位置参数如 branch <new>、remote add/remove/set-url）。
 sdd_git_verb_allowed() {
-  local cmd="$1" verb=""
+  local cmd="$1" verb="" i
   local -a tokens=()
+  case "$cmd" in
+    *"&&"*|*"|"*|*";"*|*">"*|*"<"*|*"\$("*|*"\`"*|*$'\n'*) return 1 ;;
+  esac
   read -r -a tokens <<<"$cmd"
   [[ "${tokens[0]:-}" == "git" ]] || return 1
-  local i=1
+  i=1
   while [[ $i -lt ${#tokens[@]} ]]; do
     case "${tokens[$i]}" in
       -C)
@@ -114,8 +125,19 @@ sdd_git_verb_allowed() {
     esac
   done
   [[ -n "$verb" ]] || return 1
-  case "$verb" in
-    status|diff|log|show|rev-parse|branch|remote|ls-files|diff-tree) return 0 ;;
+  if [[ "$verb" == "branch" || "$verb" == "remote" ]]; then
+    local j=$((i + 1))
+    while [[ $j -lt ${#tokens[@]} ]]; do
+      case "${tokens[$j]}" in
+        -a|-r|-v|--show-current) ;;
+        *) return 1 ;;
+      esac
+      j=$((j + 1))
+    done
+    return 0
+  fi
+  case " $(sdd_readonly_git_verbs) " in
+    *" $verb "*) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -248,14 +270,14 @@ sdd_active_task_num() {
 
 sdd_deny_message() {
   local harness="$1" task_num="$2" plan_basename="$3"
-  local plugin_root
+  local plugin_root verbs
   plugin_root="$(sdd_plugin_root_from_lib)"
+  verbs="$(sdd_readonly_git_verbs | awk '{printf "  git %s", $1; for (i = 2; i <= 7 && i <= NF; i++) printf " / git %s", $i; printf "\n  "; for (i = 8; i <= NF; i++) printf "git %s%s", $i, (i == NF ? "\n" : " / ")}')"
   cat <<-EOF
 	SDD orchestrator gate — direct repo edits forbidden during active task.
 
 	Allowed Bash (read-only diagnostics):
-	  git status / git diff / git log / git show / git rev-parse / git branch / git remote
-	  git ls-files / git diff-tree
+${verbs}
 	  ${plugin_root}/bin/sdd-run-task-${harness}.sh
 	  sdd-workspace / task-brief / review-package
 
@@ -265,7 +287,6 @@ sdd_deny_message() {
 	Repo changes flow only through:
 	  ${plugin_root}/bin/sdd-run-task-${harness}.sh --task ${task_num} --mode implement
 
-	Full matrix: docs/sdd-h6-reference.md (SDD gate matrix)
 	See spor-SDD Rule 0a item 4.
 	EOF
 }

--- a/plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh
+++ b/plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh
@@ -74,13 +74,50 @@ sdd_extract_command() {
   printf '%s' "$tool_input_json" | jq -r '.command // empty'
 }
 
-sdd_bash_allowed() {
+sdd_shell_allowed() {
   local cmd="$1"
   case "$cmd" in
     *sdd-run-task-*|*sdd-workspace*|*task-brief*|*review-package*) return 0 ;;
-    *rev-parse*) return 0 ;;
   esac
+  if sdd_git_verb_allowed "$cmd"; then
+    return 0
+  fi
   return 1
+}
+
+# 提取 git 子命令并查只读白名单。提取失败 → return 1（deny，fail-closed）。
+# 支持：git <verb>、git -C <path> <verb>、git --git-dir=<path> <verb>
+# v1 不支持：git -C <path> -c k=v <verb>（-c 配置选项）→ 提取失败 → deny
+sdd_git_verb_allowed() {
+  local cmd="$1" verb=""
+  local -a tokens=()
+  read -r -a tokens <<<"$cmd"
+  [[ "${tokens[0]:-}" == "git" ]] || return 1
+  local i=1
+  while [[ $i -lt ${#tokens[@]} ]]; do
+    case "${tokens[$i]}" in
+      -C)
+        i=$((i + 2))        # 跳过 -C 及其路径
+        continue
+        ;;
+      --git-dir=*)          # 跳过 --git-dir=<path>
+        i=$((i + 1))
+        continue
+        ;;
+      -*)                   # 其它未知 flag → 提取失败 → deny
+        return 1
+        ;;
+      *)
+        verb="${tokens[$i]}"
+        break
+        ;;
+    esac
+  done
+  [[ -n "$verb" ]] || return 1
+  case "$verb" in
+    status|diff|log|show|rev-parse|branch|remote|ls-files|diff-tree) return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 sdd_is_under_path() {
@@ -213,12 +250,24 @@ sdd_deny_message() {
   local harness="$1" task_num="$2" plan_basename="$3"
   local plugin_root
   plugin_root="$(sdd_plugin_root_from_lib)"
-  cat <<EOF
-SDD orchestrator gate — direct repo edits forbidden during active task.
-Run: ${plugin_root}/bin/sdd-run-task-${harness}.sh --task ${task_num} --mode implement
-Allowed writes: .superpowers/sdd/${plan_basename}/ only.
-See spor-SDD Rule 0a item 4.
-EOF
+  cat <<-EOF
+	SDD orchestrator gate — direct repo edits forbidden during active task.
+
+	Allowed Bash (read-only diagnostics):
+	  git status / git diff / git log / git show / git rev-parse / git branch / git remote
+	  git ls-files / git diff-tree
+	  ${plugin_root}/bin/sdd-run-task-${harness}.sh
+	  sdd-workspace / task-brief / review-package
+
+	Allowed Write:
+	  .superpowers/sdd/${plan_basename}/
+
+	Repo changes flow only through:
+	  ${plugin_root}/bin/sdd-run-task-${harness}.sh --task ${task_num} --mode implement
+
+	Full matrix: docs/sdd-h6-reference.md (SDD gate matrix)
+	See spor-SDD Rule 0a item 4.
+	EOF
 }
 
 sdd_plan_basename() {
@@ -297,7 +346,7 @@ sdd_gate_decide() {
 
   if sdd_is_shell_tool "$tool_name"; then
     cmd="$(sdd_extract_command "$tool_input_json")"
-    if sdd_bash_allowed "$cmd"; then
+    if sdd_shell_allowed "$cmd"; then
       printf 'allow\n'
       return 0
     fi

--- a/plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh
+++ b/plugins/superpowers-overrides/bin/lib/sdd-orchestrator-gate.sh
@@ -183,9 +183,12 @@ sdd_git_object_exists() {
 }
 
 sdd_find_active_workspace() {
-  local repo_root="$1"
-  local sdd_root="$repo_root/.superpowers/sdd" dir brief n handoff
+  local sdd_root="$1" repo_root dir brief n handoff
   [[ -d "$sdd_root" ]] || return 1
+  # git-object 校验绑定 sdd_root 所属仓库根（CWD 无关）。常规布局 $repo_root/.superpowers/sdd
+  # 与 fixture 布局 $TMPFIX/sdd 的仓库根深度不同，统一由 git toplevel 解析，不依赖固定上溯级数。
+  repo_root="$(git -C "$sdd_root" rev-parse --show-toplevel 2>/dev/null || true)"
+  [[ -n "$repo_root" ]] || return 1
   for dir in "$sdd_root"/*/; do
     [[ -d "$dir" ]] || continue
     n=1
@@ -324,7 +327,7 @@ sdd_plan_basename() {
 
 sdd_write_allowed() {
   local abs_path="$1" repo_root="$2" workspace="$3" phase="$4"
-  local sdd_root="$repo_root/.superpowers/sdd"
+  local sdd_root="${SDD_GATE_FIXTURES_ROOT:-$repo_root/.superpowers/sdd}"
   case "$phase" in
     inactive|task_complete) return 0 ;;
     orchestrating)
@@ -343,7 +346,7 @@ sdd_write_allowed() {
 # stdout: allow | deny|<message>
 sdd_gate_decide() {
   local harness="$1" tool_name="$2" tool_input_json="$3" session_key="$4"
-  local pending detected_at repo_root workspace phase abs_path cmd task_num plan_base msg
+  local pending detected_at repo_root sdd_root workspace phase abs_path cmd task_num plan_base msg
 
   if ! command -v jq >/dev/null 2>&1; then
     printf 'allow\n'
@@ -366,10 +369,12 @@ sdd_gate_decide() {
   repo_root="$(printf '%s' "$pending" | jq -r '.repo_root // empty')"
   [[ -n "$repo_root" ]] || { printf 'allow\n'; return 0; }
 
+  sdd_root="${SDD_GATE_FIXTURES_ROOT:-$repo_root/.superpowers/sdd}"
+
   workspace="$(sdd_resolve_workspace "$repo_root" "$pending" || true)"
   active_ws="$workspace"
   if [[ -z "$active_ws" ]]; then
-    active_ws="$(sdd_find_active_workspace "$repo_root" || true)"
+    active_ws="$(sdd_find_active_workspace "$sdd_root" || true)"
   fi
   phase="$(sdd_gate_phase "$repo_root" "$active_ws" "$pending")"
 

--- a/plugins/superpowers-overrides/bin/sdd-run-task-claude.sh
+++ b/plugins/superpowers-overrides/bin/sdd-run-task-claude.sh
@@ -4,6 +4,10 @@
 # claude invocation (source of truth for flags):
 #   claude -p "$prompt" --output-format text --dangerously-skip-permissions
 #
+#   Print mode (-p) is one-shot — no session is registered in /resume or
+#   ~/.claude/sessions/. Audit trail is ledger + handoff files, not session
+#   list. See H6.6 in sdd-h6-reference.md.
+#
 # Do not use --resume, -r/--resume, -c/--continue, or any flag that carries prior
 # session history (spec H6.5).
 # SDD_DRY_RUN=1 skips claude (argument parsing / orchestration smoke tests).

--- a/plugins/superpowers-overrides/bin/sdd-run-task-claude.sh
+++ b/plugins/superpowers-overrides/bin/sdd-run-task-claude.sh
@@ -7,7 +7,6 @@
 #   Print mode (-p) is one-shot — no session is registered in /resume or
 #   ~/.claude/sessions/. Audit trail is ledger + handoff files, not session
 #   list. See H6.6 in sdd-h6-reference.md.
-#
 # Do not use --resume, -r/--resume, -c/--continue, or any flag that carries prior
 # session history (spec H6.5).
 # SDD_DRY_RUN=1 skips claude (argument parsing / orchestration smoke tests).

--- a/plugins/superpowers-overrides/bin/sdd-run-task-cursor.sh
+++ b/plugins/superpowers-overrides/bin/sdd-run-task-cursor.sh
@@ -4,6 +4,10 @@
 # cursor-agent invocation (source of truth for flags):
 #   cursor-agent --print --output-format text --force "$prompt"
 #
+#   Print mode (--print) is one-shot — no session is registered in /resume or
+#   ~/.claude/sessions/. Audit trail is ledger + handoff files, not session
+#   list. See H6.6 in sdd-h6-reference.md.
+#
 # Do not use --resume or any flag that carries prior session history (spec H6.5).
 # SDD_DRY_RUN=1 skips cursor-agent (argument parsing / orchestration smoke tests).
 #

--- a/plugins/superpowers-overrides/docs/cross-harness-overrides.md
+++ b/plugins/superpowers-overrides/docs/cross-harness-overrides.md
@@ -71,7 +71,7 @@ Cross-harness PreToolUse enforcement for SDD orchestrator sessions (Cursor + Cla
 
 Claude Code: `hooks/hooks.json` adds `PreToolUse` matchers (`Write|Edit`, `Bash`) → `override-claude-sdd-gate.sh`. Generators are SOT — run `pnpm run generate:overrides` after manifest edits.
 
-**Shell allowance (read-only git diagnostics):** the gate allows read-only git Bash during active tasks — `git status` / `git diff` / `git log` / `git show` / `git rev-parse` / `git branch` / `git remote` / `git ls-files` / `git diff-tree` (also via `git -C <path>` / `git --git-dir=<path>`). Anything else — mutating git verbs, non-git commands, compound commands, heredocs — is denied (fail-closed). Repo changes flow only through the H6 implement shell.
+**Shell contract (read-only git diagnostics):** the gate allows read-only git Bash during active tasks — `git status` / `git diff` / `git log` / `git show` / `git rev-parse` / `git branch` / `git remote` / `git ls-files` / `git diff-tree` (also via `git -C <path>` / `git --git-dir=<path>`). Anything else — mutating git verbs, non-git commands, compound commands, heredocs — is denied (fail-closed). Repo changes flow only through the H6 implement shell or Write under the bound workspace.
 
 **Deny message:** a multi-line allowlist matrix listing every allowed Bash verb, the allowed Write root (`.superpowers/sdd/<plan-basename>/`), and the H6 implement shell. Same single-source verb list drives both the judgment and the message.
 

--- a/plugins/superpowers-overrides/docs/cross-harness-overrides.md
+++ b/plugins/superpowers-overrides/docs/cross-harness-overrides.md
@@ -71,6 +71,12 @@ Cross-harness PreToolUse enforcement for SDD orchestrator sessions (Cursor + Cla
 
 Claude Code: `hooks/hooks.json` adds `PreToolUse` matchers (`Write|Edit`, `Bash`) → `override-claude-sdd-gate.sh`. Generators are SOT — run `pnpm run generate:overrides` after manifest edits.
 
+**Shell allowance (read-only git diagnostics):** the gate allows read-only git Bash during active tasks — `git status` / `git diff` / `git log` / `git show` / `git rev-parse` / `git branch` / `git remote` / `git ls-files` / `git diff-tree` (also via `git -C <path>` / `git --git-dir=<path>`). Anything else — mutating git verbs, non-git commands, compound commands, heredocs — is denied (fail-closed). Repo changes flow only through the H6 implement shell.
+
+**Deny message:** a multi-line allowlist matrix listing every allowed Bash verb, the allowed Write root (`.superpowers/sdd/<plan-basename>/`), and the H6 implement shell. Same single-source verb list drives both the judgment and the message.
+
+**Anti-hijack:** a task brief activates only when its `TASK_BASE` is a real git object (`git -C <repo> cat-file -e <sha>`, CWD-independent) — stale stub SHAs never activate a workspace. Bound workspace (`pending.workspace`) wins; the gate scans only when unbound, so it is not hijacked by unrelated/stale workspaces. Full matrix in [`sdd-h6-reference.md`](sdd-h6-reference.md) (§ SDD gate matrix).
+
 ### SDD H6 reference doc (p1-slim.3)
 
 CLI env/exit/harness tables live in `docs/sdd-h6-reference.md`. Orchestrator skills cite H1–H5 only; Read reference doc once per session when shelling H6.

--- a/plugins/superpowers-overrides/docs/sdd-h6-reference.md
+++ b/plugins/superpowers-overrides/docs/sdd-h6-reference.md
@@ -33,6 +33,13 @@ Per-task execution uses **plugin-bundled** shell scripts — one CLI agent invoc
 
 4. **Output:** before exit, write/update `SDD_HANDOFF_PATH` (default `task-N-handoff.json` or batch variant); stdout ≤ H1 four lines; non-zero exit with no handoff → **BLOCKED**.
 5. **Forbidden:** `--resume` or any CLI invocation that carries prior session history.
+6. **Session traceability:** CLI agents use one-shot print mode (`--print` / `--output-format text`), which does NOT register sessions in the `/resume` list or `~/.claude/sessions/`.
+
+   | Concern | Approach |
+   |---------|----------|
+   | Audit trail | ledger (`progress.md`) + handoff files (`task-N-handoff.json`) + per-task reports (`task-N-report.md`) |
+   | Recovery | re-run the orchestrator shell for that task+mode |
+   | Rejected alternatives | `--session-id` (resume-only), `--name` (no session write in print mode), `--background` (daemon, incompatible with one-shot dispatch) |
 
 **Typical per-task shell sequence (mode A — thin orchestrator):**
 

--- a/plugins/superpowers-overrides/docs/sdd-h6-reference.md
+++ b/plugins/superpowers-overrides/docs/sdd-h6-reference.md
@@ -108,8 +108,13 @@ Stub harness selected → exit 1 → orchestrator **BLOCKED** (not p0 fallback).
 
 The orchestrator PreToolUse gate (`bin/lib/sdd-orchestrator-gate.sh`, p1-slim.2) blocks direct repo edits while a task is active. Judgment is one decision point — `sdd_gate_decide` resolves `active_ws` **once** (bound-ws first, scan only when unbound) and threads that same workspace through both phase and write checks.
 
+The gate is fail-open until an active task resolves (spec 安全属性 / data-flow step 1):
+
 | Tool | Condition | Decision |
 |------|-----------|----------|
+| any | `jq` missing — `sdd_gate_decide` returns allow before any check | **allow** (fail-open) |
+| any | no pending file for the session | **allow** (fail-open) |
+| any | pending expired (>24h) → pending cleared | **allow** (fail-open) |
 | Write/Edit | path under `active_ws` | **allow** |
 | Write/Edit | path under `.superpowers/sdd/**`, phase `orchestrating` | **allow** |
 | Write/Edit | phase `inactive` / `task_complete` | **allow** |
@@ -122,7 +127,7 @@ The orchestrator PreToolUse gate (`bin/lib/sdd-orchestrator-gate.sh`, p1-slim.2)
 
 **Shell contract:**
 
-- Read-only git diagnostics are allowed in every phase: `git status` / `git diff` / `git log` / `git show` / `git rev-parse` / `git branch` (read-only flags only `-a|-r|-v|--show-current`) / `git remote` (read-only flags only) / `git ls-files` / `git diff-tree`. Accepted forms: `git <verb> …`, `git -C <path> <verb> …`, `git --git-dir=<path> <verb> …`. Anything else — compound commands (`&& | ; > < $( \``), `git -C <path> -c k=v <verb>`, unknown flags, quotes — fails verb extraction → **deny** (fail-closed).
+- Read-only git diagnostics are allowed in every phase: `git status` / `git diff` / `git log` / `git show` / `git rev-parse` / `git branch` (read-only flags only `-a|-r|-v|--show-current`) / `git remote` (read-only flags only) / `git ls-files` / `git diff-tree`. Accepted forms: `git <verb> …`, `git -C <path> <verb> …`, `git --git-dir=<path> <verb> …`. Anything else — compound commands (`` && | ; > < $( ` ``), `git -C <path> -c k=v <verb>`, unknown flags, or a quote in the verb token or a branch/remote argument — fails verb extraction → **deny** (fail-closed).
 - Repo changes flow **only** through the H6 implement shell (`sdd-run-task-<harness>.sh --task N --mode implement`) or Write under the bound workspace — never via Bash (heredocs are rejected).
 - Non-git read-only commands (`ls`, `echo`, …) are intentionally still denied (slim read-only set decision; see spec §Non-goals).
 

--- a/plugins/superpowers-overrides/docs/sdd-h6-reference.md
+++ b/plugins/superpowers-overrides/docs/sdd-h6-reference.md
@@ -103,3 +103,29 @@ Stub harness selected → exit 1 → orchestrator **BLOCKED** (not p0 fallback).
 ## Mode B (opt-in / AFK)
 
 **Mode B (opt-in / AFK):** `{plugin_root}/bin/sdd-run-plan-<harness>.sh --plan <path>` reads plan + ledger; for each **pending task** runs the same 4-mode chain. Pending = no `Task N: complete` ledger line and handoff not `APPROVED` (or handoff missing). Batch blocks dispatch the entire batch's 4-mode chain once.
+
+## SDD gate matrix
+
+The orchestrator PreToolUse gate (`bin/lib/sdd-orchestrator-gate.sh`, p1-slim.2) blocks direct repo edits while a task is active. Judgment is one decision point — `sdd_gate_decide` resolves `active_ws` **once** (bound-ws first, scan only when unbound) and threads that same workspace through both phase and write checks.
+
+| Tool | Condition | Decision |
+|------|-----------|----------|
+| Write/Edit | path under `active_ws` | **allow** |
+| Write/Edit | path under `.superpowers/sdd/**`, phase `orchestrating` | **allow** |
+| Write/Edit | phase `inactive` / `task_complete` | **allow** |
+| Write/Edit | any other repo path | **deny** |
+| Bash/Shell | allowlist (`sdd-run-task-*` / `sdd-workspace` / `task-brief` / `review-package`) | **allow** |
+| Bash/Shell | read-only git verb (allowlist below) | **allow** |
+| Bash/Shell | anything else — mutating git, `ls`/`echo`, heredoc writes, compound commands | **deny** |
+| Bash/Shell | phase `inactive` / `task_complete` | **allow** |
+| other tools | — | allow |
+
+**Shell contract:**
+
+- Read-only git diagnostics are allowed in every phase: `git status` / `git diff` / `git log` / `git show` / `git rev-parse` / `git branch` (read-only flags only `-a|-r|-v|--show-current`) / `git remote` (read-only flags only) / `git ls-files` / `git diff-tree`. Accepted forms: `git <verb> …`, `git -C <path> <verb> …`, `git --git-dir=<path> <verb> …`. Anything else — compound commands (`&& | ; > < $( \``), `git -C <path> -c k=v <verb>`, unknown flags, quotes — fails verb extraction → **deny** (fail-closed).
+- Repo changes flow **only** through the H6 implement shell (`sdd-run-task-<harness>.sh --task N --mode implement`) or Write under the bound workspace — never via Bash (heredocs are rejected).
+- Non-git read-only commands (`ls`, `echo`, …) are intentionally still denied (slim read-only set decision; see spec §Non-goals).
+
+**Anti-hijack (stale workspace):** a task brief activates only when its `TASK_BASE` is a real git object — `git -C <repo> cat-file -e <sha>` (CWD-independent). Stub SHAs (`TASK_BASE: abc`) never activate a workspace. When the session is bound (`pending.workspace`), `sdd_resolve_workspace` wins and the gate never scans unrelated workspaces.
+
+**Test override:** `SDD_GATE_FIXTURES_ROOT` replaces `.superpowers/sdd` resolution in `sdd_find_active_workspace` / `sdd_gate_decide` — gate tests point it at temp copies of `tests/fixtures/sdd-gate/` (git-init'ed, brief `<SHA>` placeholders injected) and never touch the real tree. See `tests/sdd-gate-allow-deny-smoke.sh`.

--- a/plugins/superpowers-overrides/skills/spor-subagent-driven-development/SKILL.md
+++ b/plugins/superpowers-overrides/skills/spor-subagent-driven-development/SKILL.md
@@ -18,6 +18,8 @@ description: MUST invoke BEFORE superpowers:subagent-driven-development as your 
 
    **Per-task:** Rule 1 classify → Rule 4 confirm once → append `TASK_BASE: <sha>` to brief → shell H6 chain (implement → handoff/implement → review → handoff/review; fix per Rule 2) → Read handoff.json only → Rule 5a + Rule 6 → ledger on APPROVED. **Never** edit repo deliverables in this session — H6 CLI only.
 
+   **Shell 契约：** 只读 git 诊断（`git status`/`git diff`/`git log`/`git show`/`git rev-parse`/`git branch`/`git remote`/`git ls-files`/`git diff-tree`）可用；`TASK_BASE` 必须是真实 git SHA（gate 以 `git cat-file -e` 校验）。
+
    **Final:** `requesting-code-review` whole-branch in-session → clean → `finishing-a-development-branch`.
 
 ### Rule 1 — Task complexity (diff scope, test gate, model — not review rounds)

--- a/plugins/superpowers-overrides/skills/spor-subagent-driven-development/SKILL.md
+++ b/plugins/superpowers-overrides/skills/spor-subagent-driven-development/SKILL.md
@@ -18,7 +18,7 @@ description: MUST invoke BEFORE superpowers:subagent-driven-development as your 
 
    **Per-task:** Rule 1 classify → Rule 4 confirm once → append `TASK_BASE: <sha>` to brief → shell H6 chain (implement → handoff/implement → review → handoff/review; fix per Rule 2) → Read handoff.json only → Rule 5a + Rule 6 → ledger on APPROVED. **Never** edit repo deliverables in this session — H6 CLI only.
 
-   **Shell 契约：** 只读 git 诊断（`git status`/`git diff`/`git log`/`git show`/`git rev-parse`/`git branch`/`git remote`/`git ls-files`/`git diff-tree`）可用；`TASK_BASE` 必须是真实 git SHA（gate 以 `git cat-file -e` 校验）。
+   **Shell 契约：** 只读 git 诊断 Bash 在 gate 下可用（动词清单见 [`sdd-h6-reference.md` § SDD gate matrix](../../docs/sdd-h6-reference.md)）；`TASK_BASE` 必须是真实 git SHA 才激活 workspace。
 
    **Final:** `requesting-code-review` whole-branch in-session → clean → `finishing-a-development-branch`.
 

--- a/plugins/superpowers-overrides/tests/fixtures/sdd-gate/active/sdd/active-ws/task-1-brief.md
+++ b/plugins/superpowers-overrides/tests/fixtures/sdd-gate/active/sdd/active-ws/task-1-brief.md
@@ -1,0 +1,1 @@
+TASK_BASE: <SHA>

--- a/plugins/superpowers-overrides/tests/fixtures/sdd-gate/complete/sdd/complete-ws/task-1-brief.md
+++ b/plugins/superpowers-overrides/tests/fixtures/sdd-gate/complete/sdd/complete-ws/task-1-brief.md
@@ -1,0 +1,1 @@
+TASK_BASE: <SHA>

--- a/plugins/superpowers-overrides/tests/fixtures/sdd-gate/complete/sdd/complete-ws/task-1-handoff.json
+++ b/plugins/superpowers-overrides/tests/fixtures/sdd-gate/complete/sdd/complete-ws/task-1-handoff.json
@@ -1,0 +1,1 @@
+{"status":"APPROVED","phase":"implement","task":1,"commits":{"base":"<SHA>","head":"<SHA>"}}

--- a/plugins/superpowers-overrides/tests/fixtures/sdd-gate/stub/sdd/stub-ws/task-1-brief.md
+++ b/plugins/superpowers-overrides/tests/fixtures/sdd-gate/stub/sdd/stub-ws/task-1-brief.md
@@ -1,0 +1,1 @@
+TASK_BASE: abc

--- a/plugins/superpowers-overrides/tests/override-claude-sdd-gate.test.sh
+++ b/plugins/superpowers-overrides/tests/override-claude-sdd-gate.test.sh
@@ -4,18 +4,39 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 GATE="$ROOT/bin/override-claude-sdd-gate.sh"
 ACTIVATE="$ROOT/bin/sdd-session-activate.sh"
 PENDING_SDD="${TMPDIR:-/tmp}/oscaner-superpowers-overrides/pending-sdd"
+FIXTURES="$ROOT/tests/fixtures/sdd-gate"
 REPO="$(git -C "$ROOT/../.." rev-parse --show-toplevel)"
-WS="$REPO/.superpowers/sdd/dogfood-test"
-mkdir -p "$WS" "$PENDING_SDD"
+
+# 隔离 fixture：复制 active 场景根到临时目录，git init 副本 + 注入副本自身 commit SHA
+# （git-object 校验绑定副本 repo_root，副本内可解析；不修改被提交的 fixture 文件）。
+TMPFIX="$(mktemp -d)"
+trap 'rm -rf "$TMPFIX"' EXIT
+cp -R "$FIXTURES/active/." "$TMPFIX/"
+git -C "$TMPFIX" init -q
+git -C "$TMPFIX" add -A
+git -C "$TMPFIX" -c user.name="sdd-gate-fixture" -c user.email="sdd-gate-fixture@example.com" commit -qm "fixture"
+SHA="$(git -C "$TMPFIX" rev-parse --short HEAD)"
+printf 'TASK_BASE: %s\n' "$SHA" > "$TMPFIX/sdd/active-ws/task-1-brief.md"
+export SDD_GATE_FIXTURES_ROOT="$TMPFIX/sdd"
+
+mkdir -p "$PENDING_SDD"
 rm -f "$PENDING_SDD"/*.json
 
-"$ACTIVATE" minimal conv-c1 "$REPO"
+# active fixture 已含真实 SHA brief（无 APPROVED handoff）→ minimal pending 经 fixture root
+# 扫描激活 task_active（旧测试用 `TASK_BASE: abc`，T2 后 git-object 校验不激活 → 实际是 orchestrating）
+"$ACTIVATE" minimal conv-c1 "$TMPFIX"
 deny=$(printf '%s' "{\"session_id\":\"conv-c1\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$REPO/plugins/foo.txt\",\"content\":\"x\"}}" | "$GATE")
 echo "$deny" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null
 echo "$deny" | jq -e '.hookSpecificOutput.hookEventName == "PreToolUse"' >/dev/null
 echo "$deny" | jq -e '.hookSpecificOutput.permissionDecisionReason | contains("sdd-run-task-claude")' >/dev/null
 
-echo 'TASK_BASE: abc' > "$WS/task-1-brief.md"
+# 正向断言：扫描命中 active-ws → task_active。workspace 内写入 allow；
+# sdd_root 下、workspace 外的写入 deny（若扫描失败 → orchestrating → 两者皆 allow，断言失败）
+allow_ws=$(printf '%s' "{\"session_id\":\"conv-c1\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$TMPFIX/sdd/active-ws/progress.md\",\"content\":\"x\"}}" | "$GATE")
+echo "$allow_ws" | jq -e '.hookSpecificOutput.permissionDecision == "allow"' >/dev/null
+deny_scan=$(printf '%s' "{\"session_id\":\"conv-c1\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$TMPFIX/sdd/ledger.md\",\"content\":\"x\"}}" | "$GATE")
+echo "$deny_scan" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null
+
 deny_active=$(printf '%s' "{\"session_id\":\"conv-c1\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$REPO/plugins/foo.txt\",\"content\":\"x\"}}" | "$GATE")
 echo "$deny_active" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null
 

--- a/plugins/superpowers-overrides/tests/override-claude-sdd-gate.test.sh
+++ b/plugins/superpowers-overrides/tests/override-claude-sdd-gate.test.sh
@@ -2,48 +2,38 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 GATE="$ROOT/bin/override-claude-sdd-gate.sh"
-ACTIVATE="$ROOT/bin/sdd-session-activate.sh"
-PENDING_SDD="${TMPDIR:-/tmp}/oscaner-superpowers-overrides/pending-sdd"
-FIXTURES="$ROOT/tests/fixtures/sdd-gate"
+ACT="$ROOT/bin/sdd-session-activate.sh"
 REPO="$(git -C "$ROOT/../.." rev-parse --show-toplevel)"
 
-# 隔离 fixture：复制 active 场景根到临时目录，git init 副本 + 注入副本自身 commit SHA
-# （git-object 校验绑定副本 repo_root，副本内可解析；不修改被提交的 fixture 文件）。
-TMPFIX="$(mktemp -d)"
-trap 'rm -rf "$TMPFIX"' EXIT
-cp -R "$FIXTURES/active/." "$TMPFIX/"
-git -C "$TMPFIX" init -q
-git -C "$TMPFIX" add -A
-git -C "$TMPFIX" -c user.name="sdd-gate-fixture" -c user.email="sdd-gate-fixture@example.com" commit -qm "fixture"
-SHA="$(git -C "$TMPFIX" rev-parse --short HEAD)"
-printf 'TASK_BASE: %s\n' "$SHA" > "$TMPFIX/sdd/active-ws/task-1-brief.md"
-export SDD_GATE_FIXTURES_ROOT="$TMPFIX/sdd"
-
-mkdir -p "$PENDING_SDD"
-rm -f "$PENDING_SDD"/*.json
+# 隔离 fixture + per-run session 命名：共享 sdd-gate-test-lib.sh（见该文件头注释）。
+# shellcheck source=tests/sdd-gate-test-lib.sh
+source "$ROOT/tests/sdd-gate-test-lib.sh"
 
 # active fixture 已含真实 SHA brief（无 APPROVED handoff）→ minimal pending 经 fixture root
 # 扫描激活 task_active（旧测试用 `TASK_BASE: abc`，T2 后 git-object 校验不激活 → 实际是 orchestrating）
-"$ACTIVATE" minimal conv-c1 "$TMPFIX"
-deny=$(printf '%s' "{\"session_id\":\"conv-c1\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$REPO/plugins/foo.txt\",\"content\":\"x\"}}" | "$GATE")
+KEY="$(session_key conv-c)"
+setup_scenario active active-ws "$KEY"
+FIX="$SCEN_DEST"
+
+deny=$(printf '%s' "{\"session_id\":\"$KEY\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$REPO/plugins/foo.txt\",\"content\":\"x\"}}" | "$GATE")
 echo "$deny" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null
 echo "$deny" | jq -e '.hookSpecificOutput.hookEventName == "PreToolUse"' >/dev/null
 echo "$deny" | jq -e '.hookSpecificOutput.permissionDecisionReason | contains("sdd-run-task-claude")' >/dev/null
 
 # 正向断言：扫描命中 active-ws → task_active。workspace 内写入 allow；
 # sdd_root 下、workspace 外的写入 deny（若扫描失败 → orchestrating → 两者皆 allow，断言失败）
-allow_ws=$(printf '%s' "{\"session_id\":\"conv-c1\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$TMPFIX/sdd/active-ws/progress.md\",\"content\":\"x\"}}" | "$GATE")
+allow_ws=$(printf '%s' "{\"session_id\":\"$KEY\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$FIX/sdd/active-ws/progress.md\",\"content\":\"x\"}}" | "$GATE")
 echo "$allow_ws" | jq -e '.hookSpecificOutput.permissionDecision == "allow"' >/dev/null
-deny_scan=$(printf '%s' "{\"session_id\":\"conv-c1\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$TMPFIX/sdd/ledger.md\",\"content\":\"x\"}}" | "$GATE")
+deny_scan=$(printf '%s' "{\"session_id\":\"$KEY\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$FIX/sdd/ledger.md\",\"content\":\"x\"}}" | "$GATE")
 echo "$deny_scan" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null
 
-deny_active=$(printf '%s' "{\"session_id\":\"conv-c1\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$REPO/plugins/foo.txt\",\"content\":\"x\"}}" | "$GATE")
+deny_active=$(printf '%s' "{\"session_id\":\"$KEY\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"$REPO/plugins/foo.txt\",\"content\":\"x\"}}" | "$GATE")
 echo "$deny_active" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null
 
-deny_bash=$(printf '%s' "{\"session_id\":\"conv-c1\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"rm -rf $REPO/plugins\"}}" | "$GATE")
+deny_bash=$(printf '%s' "{\"session_id\":\"$KEY\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"rm -rf $REPO/plugins\"}}" | "$GATE")
 echo "$deny_bash" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null
 
-allow_h6=$(printf '%s' "{\"session_id\":\"conv-c1\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$ROOT/bin/sdd-run-task-claude.sh --task 1 --mode implement\"}}" | "$GATE")
+allow_h6=$(printf '%s' "{\"session_id\":\"$KEY\",\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$ROOT/bin/sdd-run-task-claude.sh --task 1 --mode implement\"}}" | "$GATE")
 echo "$allow_h6" | jq -e '.hookSpecificOutput.permissionDecision == "allow"' >/dev/null
 
 echo "OK — override-claude-sdd-gate"

--- a/plugins/superpowers-overrides/tests/override-cursor-sdd-gate.test.sh
+++ b/plugins/superpowers-overrides/tests/override-cursor-sdd-gate.test.sh
@@ -2,50 +2,40 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 GATE="$ROOT/bin/override-cursor-sdd-gate.sh"
-ACTIVATE="$ROOT/bin/sdd-session-activate.sh"
-PENDING_SDD="${TMPDIR:-/tmp}/oscaner-superpowers-overrides/pending-sdd"
-FIXTURES="$ROOT/tests/fixtures/sdd-gate"
+ACT="$ROOT/bin/sdd-session-activate.sh"
 REPO="$(git -C "$ROOT/../.." rev-parse --show-toplevel)"
 
-# 隔离 fixture：复制 active 场景根到临时目录，git init 副本 + 注入副本自身 commit SHA
-# （git-object 校验绑定副本 repo_root，副本内可解析；不修改被提交的 fixture 文件）。
-TMPFIX="$(mktemp -d)"
-trap 'rm -rf "$TMPFIX"' EXIT
-cp -R "$FIXTURES/active/." "$TMPFIX/"
-git -C "$TMPFIX" init -q
-git -C "$TMPFIX" add -A
-git -C "$TMPFIX" -c user.name="sdd-gate-fixture" -c user.email="sdd-gate-fixture@example.com" commit -qm "fixture"
-SHA="$(git -C "$TMPFIX" rev-parse --short HEAD)"
-printf 'TASK_BASE: %s\n' "$SHA" > "$TMPFIX/sdd/active-ws/task-1-brief.md"
-export SDD_GATE_FIXTURES_ROOT="$TMPFIX/sdd"
-WS="$TMPFIX/sdd/active-ws"
-
-mkdir -p "$PENDING_SDD"
-rm -f "$PENDING_SDD"/*.json
+# 隔离 fixture + per-run session 命名：共享 sdd-gate-test-lib.sh（见该文件头注释）。
+# shellcheck source=tests/sdd-gate-test-lib.sh
+source "$ROOT/tests/sdd-gate-test-lib.sh"
 
 # AC#3 minimal pending — active-ws 已含真实 SHA brief（无 APPROVED handoff）→ 扫描命中 task_active。
 # 仓库路径 Write deny + 只读 git allow 在 orchestrating/task_active 下判定一致；
 # 下方 deny_scan（sdd_root 下、workspace 外）是正向判别：仅扫描命中 task_active 时 deny，
 # 若扫描失败 → orchestrating → allow，断言失败。
-"$ACTIVATE" minimal conv-g1 "$TMPFIX"
-deny_orch=$(printf '%s' "{\"conversation_id\":\"conv-g1\",\"tool_name\":\"Write\",\"tool_input\":{\"path\":\"$REPO/plugins/foo.txt\",\"contents\":\"x\"}}" | "$GATE")
+KEY="$(session_key conv-g)"
+setup_scenario active active-ws "$KEY"
+FIX="$SCEN_DEST"
+WS="$FIX/sdd/active-ws"
+
+deny_orch=$(printf '%s' "{\"conversation_id\":\"$KEY\",\"tool_name\":\"Write\",\"tool_input\":{\"path\":\"$REPO/plugins/foo.txt\",\"contents\":\"x\"}}" | "$GATE")
 echo "$deny_orch" | jq -e '.permission == "deny"' >/dev/null
-allow_git=$(printf '%s' "{\"conversation_id\":\"conv-g1\",\"tool_name\":\"Shell\",\"tool_input\":{\"command\":\"git -C $REPO rev-parse HEAD\"}}" | "$GATE")
+allow_git=$(printf '%s' "{\"conversation_id\":\"$KEY\",\"tool_name\":\"Shell\",\"tool_input\":{\"command\":\"git -C $REPO rev-parse HEAD\"}}" | "$GATE")
 echo "$allow_git" | jq -e '.permission == "allow"' >/dev/null
-deny_scan=$(printf '%s' "{\"conversation_id\":\"conv-g1\",\"tool_name\":\"Write\",\"tool_input\":{\"path\":\"$TMPFIX/sdd/ledger.md\",\"contents\":\"x\"}}" | "$GATE")
+deny_scan=$(printf '%s' "{\"conversation_id\":\"$KEY\",\"tool_name\":\"Write\",\"tool_input\":{\"path\":\"$FIX/sdd/ledger.md\",\"contents\":\"x\"}}" | "$GATE")
 echo "$deny_scan" | jq -e '.permission == "deny"' >/dev/null
 
 # AC#4 TASK_ACTIVE — bind workspace（active fixture 已含真实 SHA brief，无 APPROVED handoff）
-"$ACTIVATE" bind conv-g1 "$TMPFIX" "dogfood-plan.md" "$WS"
-deny_active=$(printf '%s' "{\"conversation_id\":\"conv-g1\",\"tool_name\":\"Write\",\"tool_input\":{\"path\":\"$REPO/plugins/foo.txt\",\"contents\":\"x\"}}" | "$GATE")
+"$ACT" bind "$KEY" "$FIX" "dogfood-plan.md" "$WS"
+deny_active=$(printf '%s' "{\"conversation_id\":\"$KEY\",\"tool_name\":\"Write\",\"tool_input\":{\"path\":\"$REPO/plugins/foo.txt\",\"contents\":\"x\"}}" | "$GATE")
 echo "$deny_active" | jq -e '.permission == "deny"' >/dev/null
-allow_ws=$(printf '%s' "{\"conversation_id\":\"conv-g1\",\"tool_name\":\"Write\",\"tool_input\":{\"path\":\"$WS/progress.md\",\"contents\":\"# ledger\"}}" | "$GATE")
+allow_ws=$(printf '%s' "{\"conversation_id\":\"$KEY\",\"tool_name\":\"Write\",\"tool_input\":{\"path\":\"$WS/progress.md\",\"contents\":\"# ledger\"}}" | "$GATE")
 echo "$allow_ws" | jq -e '.permission == "allow"' >/dev/null
 
 # AC#5 Bash allowlist during TASK_ACTIVE
-allow_h6=$(printf '%s' "{\"conversation_id\":\"conv-g1\",\"tool_name\":\"Shell\",\"tool_input\":{\"command\":\"$ROOT/bin/sdd-run-task-cursor.sh --task 1 --mode implement --plan foo.md\"}}" | "$GATE")
+allow_h6=$(printf '%s' "{\"conversation_id\":\"$KEY\",\"tool_name\":\"Shell\",\"tool_input\":{\"command\":\"$ROOT/bin/sdd-run-task-cursor.sh --task 1 --mode implement --plan foo.md\"}}" | "$GATE")
 echo "$allow_h6" | jq -e '.permission == "allow"' >/dev/null
-deny_bash=$(printf '%s' "{\"conversation_id\":\"conv-g1\",\"tool_name\":\"Shell\",\"tool_input\":{\"command\":\"rm -rf $REPO/plugins\"}}" | "$GATE")
+deny_bash=$(printf '%s' "{\"conversation_id\":\"$KEY\",\"tool_name\":\"Shell\",\"tool_input\":{\"command\":\"rm -rf $REPO/plugins\"}}" | "$GATE")
 echo "$deny_bash" | jq -e '.permission == "deny"' >/dev/null
 
 # fail-open — no pending

--- a/plugins/superpowers-overrides/tests/override-cursor-sdd-gate.test.sh
+++ b/plugins/superpowers-overrides/tests/override-cursor-sdd-gate.test.sh
@@ -4,21 +4,39 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 GATE="$ROOT/bin/override-cursor-sdd-gate.sh"
 ACTIVATE="$ROOT/bin/sdd-session-activate.sh"
 PENDING_SDD="${TMPDIR:-/tmp}/oscaner-superpowers-overrides/pending-sdd"
+FIXTURES="$ROOT/tests/fixtures/sdd-gate"
 REPO="$(git -C "$ROOT/../.." rev-parse --show-toplevel)"
-WS="$REPO/.superpowers/sdd/dogfood-test"
-mkdir -p "$WS" "$PENDING_SDD"
+
+# 隔离 fixture：复制 active 场景根到临时目录，git init 副本 + 注入副本自身 commit SHA
+# （git-object 校验绑定副本 repo_root，副本内可解析；不修改被提交的 fixture 文件）。
+TMPFIX="$(mktemp -d)"
+trap 'rm -rf "$TMPFIX"' EXIT
+cp -R "$FIXTURES/active/." "$TMPFIX/"
+git -C "$TMPFIX" init -q
+git -C "$TMPFIX" add -A
+git -C "$TMPFIX" -c user.name="sdd-gate-fixture" -c user.email="sdd-gate-fixture@example.com" commit -qm "fixture"
+SHA="$(git -C "$TMPFIX" rev-parse --short HEAD)"
+printf 'TASK_BASE: %s\n' "$SHA" > "$TMPFIX/sdd/active-ws/task-1-brief.md"
+export SDD_GATE_FIXTURES_ROOT="$TMPFIX/sdd"
+WS="$TMPFIX/sdd/active-ws"
+
+mkdir -p "$PENDING_SDD"
 rm -f "$PENDING_SDD"/*.json
 
-# AC#3 ORCHESTRATING — pending, NO TASK_BASE
-"$ACTIVATE" minimal conv-g1 "$REPO"
+# AC#3 minimal pending — active-ws 已含真实 SHA brief（无 APPROVED handoff）→ 扫描命中 task_active。
+# 仓库路径 Write deny + 只读 git allow 在 orchestrating/task_active 下判定一致；
+# 下方 deny_scan（sdd_root 下、workspace 外）是正向判别：仅扫描命中 task_active 时 deny，
+# 若扫描失败 → orchestrating → allow，断言失败。
+"$ACTIVATE" minimal conv-g1 "$TMPFIX"
 deny_orch=$(printf '%s' "{\"conversation_id\":\"conv-g1\",\"tool_name\":\"Write\",\"tool_input\":{\"path\":\"$REPO/plugins/foo.txt\",\"contents\":\"x\"}}" | "$GATE")
 echo "$deny_orch" | jq -e '.permission == "deny"' >/dev/null
 allow_git=$(printf '%s' "{\"conversation_id\":\"conv-g1\",\"tool_name\":\"Shell\",\"tool_input\":{\"command\":\"git -C $REPO rev-parse HEAD\"}}" | "$GATE")
 echo "$allow_git" | jq -e '.permission == "allow"' >/dev/null
+deny_scan=$(printf '%s' "{\"conversation_id\":\"conv-g1\",\"tool_name\":\"Write\",\"tool_input\":{\"path\":\"$TMPFIX/sdd/ledger.md\",\"contents\":\"x\"}}" | "$GATE")
+echo "$deny_scan" | jq -e '.permission == "deny"' >/dev/null
 
-# AC#4 TASK_ACTIVE — bind workspace, add TASK_BASE, no APPROVED handoff
-"$ACTIVATE" bind conv-g1 "$REPO" "dogfood-plan.md" "$WS"
-echo 'TASK_BASE: abc' > "$WS/task-1-brief.md"
+# AC#4 TASK_ACTIVE — bind workspace（active fixture 已含真实 SHA brief，无 APPROVED handoff）
+"$ACTIVATE" bind conv-g1 "$TMPFIX" "dogfood-plan.md" "$WS"
 deny_active=$(printf '%s' "{\"conversation_id\":\"conv-g1\",\"tool_name\":\"Write\",\"tool_input\":{\"path\":\"$REPO/plugins/foo.txt\",\"contents\":\"x\"}}" | "$GATE")
 echo "$deny_active" | jq -e '.permission == "deny"' >/dev/null
 allow_ws=$(printf '%s' "{\"conversation_id\":\"conv-g1\",\"tool_name\":\"Write\",\"tool_input\":{\"path\":\"$WS/progress.md\",\"contents\":\"# ledger\"}}" | "$GATE")

--- a/plugins/superpowers-overrides/tests/sdd-gate-allow-deny-smoke.sh
+++ b/plugins/superpowers-overrides/tests/sdd-gate-allow-deny-smoke.sh
@@ -11,188 +11,169 @@ set -euo pipefail
 #   - deny message is the multi-line allowlist matrix (lists git show etc.)
 #   - task_complete phase re-allows shell + Write (realtime phase, no caching)
 #
-# Fixture isolation (spec §设计 fixture): each scenario is copied to a temp dir,
-# git-init'ed, and briefs carrying `TASK_BASE: <SHA>` get the copy's real short SHA
-# injected — tracked fixture files are never modified (P4 anti-pattern).
+# Fixture isolation: shared sdd-gate-test-lib.sh copies each scenario to a temp
+# dir, git-inits it, injects the copy's own short-SHA into `<SHA>` briefs, and
+# namespaces session keys per-run — a concurrent run or a live SDD session's
+# pending file is never touched (see finding: global find -delete clobbers).
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 GATE="$ROOT/bin/override-claude-sdd-gate.sh"
 ACT="$ROOT/bin/sdd-session-activate.sh"
-FIXTURES="$ROOT/tests/fixtures/sdd-gate"
 REPO="$(git -C "$ROOT/../.." rev-parse --show-toplevel)"
 
-PENDING="${TMPDIR:-/tmp}/oscaner-superpowers-overrides/pending-sdd"
-mkdir -p "$PENDING"
-find "$PENDING" -name '*.json' -delete
-
-TMPROOT="$(mktemp -d)"
-trap 'rm -rf "$TMPROOT"; find "$PENDING" -name "*.json" -delete' EXIT
+# shellcheck source=tests/sdd-gate-test-lib.sh
+source "$ROOT/tests/sdd-gate-test-lib.sh"
 
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
-SESSION=""
 ASSERT_COUNT=0
-
-# make_fixture_copy <scenario> <dest-name> — copy a fixture scene root into
-# $TMPROOT/<dest-name>, git-init the copy, and inject the copy's real short SHA
-# into any `TASK_BASE: <SHA>` brief placeholder (stub briefs keep `abc`).
-# Exports SDD_GATE_FIXTURES_ROOT so the gate scans the copy, not the real tree.
-make_fixture_copy() {
-  local scen="$1" name="$2" sha b
-  TMPFIX="$TMPROOT/$name"
-  cp -R "$FIXTURES/$scen/." "$TMPFIX/"
-  git -C "$TMPFIX" init -q
-  git -C "$TMPFIX" add -A
-  git -C "$TMPFIX" -c user.name="sdd-gate-smoke" -c user.email="sdd-gate-smoke@example.com" \
-    commit --allow-empty -qm "fixture"
-  sha="$(git -C "$TMPFIX" rev-parse --short HEAD)"
-  while IFS= read -r b; do
-    if grep -q 'TASK_BASE: <SHA>' "$b"; then
-      printf 'TASK_BASE: %s\n' "$sha" > "$b"
-    fi
-  done < <(find "$TMPFIX" -name 'task-*-brief.md')
-  export SDD_GATE_FIXTURES_ROOT="$TMPFIX/sdd"
-}
 
 # gate_json <tool_name> <tool_input_json> — run the adapter, return full JSON.
 gate_json() {
   local json
-  json="$(jq -nc --arg sid "$SESSION" --arg tn "$1" --argjson ti "$2" \
+  json="$(jq -nc --arg sid "$1" --arg tn "$2" --argjson ti "$3" \
     '{session_id:$sid, tool_name:$tn, tool_input:$ti}')"
   printf '%s' "$json" | "$GATE"
 }
 
-decision() { gate_json "$1" "$2" | jq -r '.hookSpecificOutput.permissionDecision'; }
-bash_decision() { decision Bash "$(jq -nc --arg c "$1" '{command:$c}')"; }
-write_decision() { decision Write "$(jq -nc --arg p "$1" '{file_path:$p}')"; }
-bash_reason() { gate_json Bash "$(jq -nc --arg c "$1" '{command:$c}')" | jq -r '.hookSpecificOutput.permissionDecisionReason'; }
+decision() { gate_json "$1" "$2" "$3" | jq -r '.hookSpecificOutput.permissionDecision'; }
+bash_decision() { decision "$1" Bash "$(jq -nc --arg c "$2" '{command:$c}')"; }
+write_decision() { decision "$1" Write "$(jq -nc --arg p "$2" '{file_path:$p}')"; }
+bash_reason() { gate_json "$1" Bash "$(jq -nc --arg c "$2" '{command:$c}')" | jq -r '.hookSpecificOutput.permissionDecisionReason'; }
 
-assert_allow_cmd() { [[ "$(bash_decision "$1")" == allow ]] || fail "expected allow: $2"; ASSERT_COUNT=$((ASSERT_COUNT + 1)); }
-assert_deny_cmd() { [[ "$(bash_decision "$1")" == deny ]] || fail "expected deny: $2"; ASSERT_COUNT=$((ASSERT_COUNT + 1)); }
-assert_allow_write() { [[ "$(write_decision "$1")" == allow ]] || fail "expected allow: $2"; ASSERT_COUNT=$((ASSERT_COUNT + 1)); }
-assert_deny_write() { [[ "$(write_decision "$1")" == deny ]] || fail "expected deny: $2"; ASSERT_COUNT=$((ASSERT_COUNT + 1)); }
-assert_other_allow() { [[ "$(decision "$1" "$2")" == allow ]] || fail "expected allow: $3"; ASSERT_COUNT=$((ASSERT_COUNT + 1)); }
+assert_allow_cmd() { [[ "$(bash_decision "$1" "$2")" == allow ]] || fail "expected allow: $3"; ASSERT_COUNT=$((ASSERT_COUNT + 1)); }
+assert_deny_cmd() { [[ "$(bash_decision "$1" "$2")" == deny ]] || fail "expected deny: $3"; ASSERT_COUNT=$((ASSERT_COUNT + 1)); }
+assert_allow_write() { [[ "$(write_decision "$1" "$2")" == allow ]] || fail "expected allow: $3"; ASSERT_COUNT=$((ASSERT_COUNT + 1)); }
+assert_deny_write() { [[ "$(write_decision "$1" "$2")" == deny ]] || fail "expected deny: $3"; ASSERT_COUNT=$((ASSERT_COUNT + 1)); }
+assert_other_allow() { [[ "$(decision "$1" "$2" "$3")" == allow ]] || fail "expected allow: $4"; ASSERT_COUNT=$((ASSERT_COUNT + 1)); }
 
-assert_reason_contains() {  # <needle> <desc> — matrix text against a representative deny
+assert_reason_contains() {  # <session> <needle> <desc> — matrix text against a representative deny
   local r
-  r="$(bash_reason "ls")"
-  [[ "$r" == *"$1"* ]] || fail "deny message missing '$1': $2"
+  r="$(bash_reason "$1" "ls")"
+  [[ "$r" == *"$2"* ]] || fail "deny message missing '$2': $3"
   ASSERT_COUNT=$((ASSERT_COUNT + 1))
 }
 
 echo "== 1. active-ws (minimal → scan → task_active) =="
-SESSION="smk-active"
-make_fixture_copy active active-ws
-"$ACT" minimal "$SESSION" "$TMPFIX"
+S1="$(session_key active)"
+setup_scenario active active-ws "$S1"
 
 # read-only git diagnostics allow (AC1 boundary cases)
-assert_allow_cmd "git status" "git status"
-assert_allow_cmd "git -C $REPO status" "git -C <repo> status"
-assert_allow_cmd "git --git-dir=$REPO/.git status" "git --git-dir=<repo> status"
-assert_allow_cmd "git diff HEAD~1" "git diff HEAD~1"
-assert_allow_cmd "git rev-parse HEAD" "git rev-parse HEAD"
-assert_allow_cmd "git branch -a" "git branch -a"
-assert_allow_cmd "git remote -v" "git remote -v"
-assert_allow_cmd "git ls-files" "git ls-files"
-assert_allow_cmd "git diff-tree --stat HEAD" "git diff-tree"
+assert_allow_cmd "$S1" "git status" "git status"
+assert_allow_cmd "$S1" "git -C $REPO status" "git -C <repo> status"
+assert_allow_cmd "$S1" "git --git-dir=$REPO/.git status" "git --git-dir=<repo> status"
+assert_allow_cmd "$S1" "git diff HEAD~1" "git diff HEAD~1"
+assert_allow_cmd "$S1" "git rev-parse HEAD" "git rev-parse HEAD"
+assert_allow_cmd "$S1" "git branch -a" "git branch -a"
+assert_allow_cmd "$S1" "git remote -v" "git remote -v"
+assert_allow_cmd "$S1" "git ls-files" "git ls-files"
+assert_allow_cmd "$S1" "git diff-tree --stat HEAD" "git diff-tree"
 
 # AC1 v1 out-of-scope: `-c` config option not in extraction range → deny
-assert_deny_cmd "git -C $REPO -c k=v status" "git -C <repo> -c k=v status (v1 deny)"
+assert_deny_cmd "$S1" "git -C $REPO -c k=v status" "git -C <repo> -c k=v status (v1 deny)"
 
 # mutating git verbs deny
-assert_deny_cmd "git add foo" "git add"
-assert_deny_cmd "git commit -m x" "git commit"
-assert_deny_cmd "git push origin main" "git push"
-assert_deny_cmd "git branch -d foo" "git branch -d (mutating sub-verb)"
-assert_deny_cmd "git remote add origin $REPO" "git remote add (mutating sub-verb)"
+assert_deny_cmd "$S1" "git add foo" "git add"
+assert_deny_cmd "$S1" "git commit -m x" "git commit"
+assert_deny_cmd "$S1" "git push origin main" "git push"
+assert_deny_cmd "$S1" "git branch -d foo" "git branch -d (mutating sub-verb)"
+assert_deny_cmd "$S1" "git remote add origin $REPO" "git remote add (mutating sub-verb)"
 
 # non-git commands still deny (spec Non-goals: ls/echo not in the read-only set)
-assert_deny_cmd "ls" "ls"
-assert_deny_cmd "echo hi" "echo"
+assert_deny_cmd "$S1" "ls" "ls"
+assert_deny_cmd "$S1" "echo hi" "echo"
 
 # allowlist Bash
-assert_allow_cmd "$ROOT/bin/sdd-run-task-claude.sh --task 1 --mode implement" "H6 sdd-run-task"
-assert_allow_cmd "sdd-workspace create x" "sdd-workspace"
-assert_allow_cmd "task-brief --task 1" "task-brief"
-assert_allow_cmd "review-package --task 1" "review-package"
+assert_allow_cmd "$S1" "$ROOT/bin/sdd-run-task-claude.sh --task 1 --mode implement" "H6 sdd-run-task"
+assert_allow_cmd "$S1" "sdd-workspace create x" "sdd-workspace"
+assert_allow_cmd "$S1" "task-brief --task 1" "task-brief"
+assert_allow_cmd "$S1" "review-package --task 1" "review-package"
 
 # Write: workspace allow, other repo paths deny
-assert_allow_write "$TMPFIX/sdd/active-ws/progress.md" "write active-ws"
-assert_deny_write "$TMPFIX/sdd/ledger.md" "write sdd_root ledger (outside active-ws)"
-assert_deny_write "$REPO/plugins/foo.txt" "write repo path (task_active)"
+assert_allow_write "$S1" "$TMPROOT/active-ws/sdd/active-ws/progress.md" "write active-ws"
+assert_deny_write "$S1" "$TMPROOT/active-ws/sdd/ledger.md" "write sdd_root ledger (outside active-ws)"
+assert_deny_write "$S1" "$REPO/plugins/foo.txt" "write repo path (task_active)"
 
 # other tools always allow
-assert_other_allow Read '{}' "Read tool"
+assert_other_allow "$S1" Read '{}' "Read tool"
 
 # adapter JSON shape (hookSpecificOutput.permissionDecision / hookEventName / reason)
-out="$(gate_json Bash "$(jq -nc --arg c "ls" '{command:$c}')")"
+out="$(gate_json "$S1" Bash "$(jq -nc --arg c "ls" '{command:$c}')")"
 printf '%s' "$out" | jq -e '.hookSpecificOutput.hookEventName == "PreToolUse"' >/dev/null || fail "hookEventName != PreToolUse"
 printf '%s' "$out" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null || fail "shape: expected deny"
 printf '%s' "$out" | jq -e '(.hookSpecificOutput.permissionDecisionReason | length) > 0' >/dev/null || fail "empty permissionDecisionReason"
 ASSERT_COUNT=$((ASSERT_COUNT + 1))
 
-# deny message is the multi-line matrix: git show listed, H6 command, workspace scope
+# deny message is the multi-line matrix: every line of sdd_deny_message, so
+# drift in any matrix row goes uncaught nowhere (spec AC5, 含 git show).
 for needle in "SDD orchestrator gate" "Allowed Bash (read-only diagnostics):" \
               "git status" "git diff" "git log" "git show" "git rev-parse" \
-              "sdd-run-task-claude.sh" "Allowed Write:" ".superpowers/sdd/active-ws/" \
-              "--task 1 --mode implement"; do
-  r="$(bash_reason "ls")"
+              "git branch" "git remote" "git ls-files" "git diff-tree" \
+              "sdd-run-task-claude.sh" "sdd-workspace / task-brief / review-package" \
+              "Allowed Write:" ".superpowers/sdd/active-ws/" \
+              "--task 1 --mode implement" "See spor-SDD Rule 0a item 4."; do
+  r="$(bash_reason "$S1" "ls")"
   [[ "$r" == *"$needle"* ]] || fail "deny message missing: $needle"
 done
 ASSERT_COUNT=$((ASSERT_COUNT + 1))
 
 echo "== 2. stub-ws (TASK_BASE: abc → not a git object → orchestrating, no hijack) =="
-SESSION="smk-stub"
-make_fixture_copy stub stub-ws
-"$ACT" minimal "$SESSION" "$TMPFIX"
+S2="$(session_key stub)"
+setup_scenario stub stub-ws "$S2"
 
 # stub brief keeps `TASK_BASE: abc` (no <SHA> placeholder) — must NOT activate
 # (git-object validation fails). Phase stays orchestrating: read-only git +
 # sdd_root writes allow, direct repo edits deny.
-assert_allow_cmd "git status" "git status (orchestrating)"
-assert_allow_write "$TMPFIX/sdd/stub-ws/x.md" "write stub-ws (orchestrating sdd_root)"
-assert_allow_write "$TMPFIX/sdd/ledger.md" "write sdd_root ledger (orchestrating)"
-assert_deny_write "$REPO/plugins/foo.txt" "write repo path (orchestrating)"
-assert_deny_cmd "ls" "ls (orchestrating)"
+assert_allow_cmd "$S2" "git status" "git status (orchestrating)"
+assert_allow_write "$S2" "$TMPROOT/stub-ws/sdd/stub-ws/x.md" "write stub-ws (orchestrating sdd_root)"
+assert_allow_write "$S2" "$TMPROOT/stub-ws/sdd/ledger.md" "write sdd_root ledger (orchestrating)"
+assert_deny_write "$S2" "$REPO/plugins/foo.txt" "write repo path (orchestrating)"
+assert_deny_cmd "$S2" "ls" "ls (orchestrating)"
 
 # plan basename falls back to unknown-plan → proves stub-ws was NOT activated
-assert_reason_contains "unknown-plan" "stub-ws hijack check (expected unknown-plan)"
+assert_reason_contains "$S2" "unknown-plan" "stub-ws hijack check (expected unknown-plan)"
 
 echo "== 3. bound-ws (bind → bound workspace wins, unrelated ws not scanned) =="
-SESSION="smk-bound"
-make_fixture_copy active bound-ws
-mkdir -p "$TMPFIX/sdd/unrelated-ws"
-printf 'TASK_BASE: %s\n' "$(git -C "$TMPFIX" rev-parse --short HEAD)" > "$TMPFIX/sdd/unrelated-ws/task-1-brief.md"
-"$ACT" bind "$SESSION" "$TMPFIX" "$TMPFIX/plan.md" "$TMPFIX/sdd/active-ws"
+S3="$(session_key bound)"
+setup_scenario active bound-ws
+BOUND_FIX="$SCEN_DEST"
+# unrelated brief is lexically-first active candidate (000-) — under a scan
+# regression sdd_find_active_workspace would select it and the bound-ws
+# assertions below would fail, so bound precedence is a real discriminator.
+mkdir -p "$TMPROOT/bound-ws/sdd/000-unrelated-ws"
+printf 'TASK_BASE: %s\n' "$(git -C "$TMPROOT/bound-ws" rev-parse --short HEAD)" > "$TMPROOT/bound-ws/sdd/000-unrelated-ws/task-1-brief.md"
+"$ACT" bind "$S3" "$BOUND_FIX" "$BOUND_FIX/plan.md" "$BOUND_FIX/sdd/active-ws"
+SESSION_KEYS+=("$S3")
 
-assert_allow_write "$TMPFIX/sdd/active-ws/progress.md" "write bound active-ws"
-assert_deny_write "$TMPFIX/sdd/unrelated-ws/x.md" "write unrelated-ws (bound wins, not scanned)"
-assert_deny_write "$REPO/plugins/foo.txt" "write repo path (task_active)"
-assert_deny_cmd "git add foo" "git add (task_active)"
-assert_allow_cmd "git status" "git status (task_active)"
+assert_allow_write "$S3" "$TMPROOT/bound-ws/sdd/active-ws/progress.md" "write bound active-ws"
+assert_deny_write "$S3" "$TMPROOT/bound-ws/sdd/000-unrelated-ws/x.md" "write unrelated-ws (bound wins, not scanned)"
+assert_deny_write "$S3" "$REPO/plugins/foo.txt" "write repo path (task_active)"
+assert_deny_cmd "$S3" "git add foo" "git add (task_active)"
+assert_allow_cmd "$S3" "git status" "git status (task_active)"
 
 # bound deny message resolves plan basename from plan_path (plan.md → plan)
-assert_reason_contains ".superpowers/sdd/plan/" "bound deny message should use plan_path basename"
+assert_reason_contains "$S3" ".superpowers/sdd/plan/" "bound deny message should use plan_path basename"
 
 echo "== 4. complete-ws (APPROVED handoff + real SHA → task_complete → shell/Write allow) =="
-SESSION="smk-complete"
-make_fixture_copy complete complete-ws
-"$ACT" bind "$SESSION" "$TMPFIX" "$TMPFIX/plan.md" "$TMPFIX/sdd/complete-ws"
+S4="$(session_key complete)"
+setup_scenario complete complete-ws
+COMPLETE_FIX="$SCEN_DEST"
+"$ACT" bind "$S4" "$COMPLETE_FIX" "$COMPLETE_FIX/plan.md" "$COMPLETE_FIX/sdd/complete-ws"
+SESSION_KEYS+=("$S4")
 
 # task_complete: shell and Write re-allowed (realtime phase, no caching)
-assert_allow_cmd "ls" "bash ls (task_complete)"
-assert_allow_cmd "git add foo" "bash git add (task_complete)"
-assert_allow_write "$REPO/plugins/foo.txt" "write repo path (task_complete)"
-assert_allow_write "$TMPFIX/sdd/complete-ws/x.md" "write complete-ws (task_complete)"
+assert_allow_cmd "$S4" "ls" "bash ls (task_complete)"
+assert_allow_cmd "$S4" "git add foo" "bash git add (task_complete)"
+assert_allow_write "$S4" "$REPO/plugins/foo.txt" "write repo path (task_complete)"
+assert_allow_write "$S4" "$TMPROOT/complete-ws/sdd/complete-ws/x.md" "write complete-ws (task_complete)"
 
 echo "== 5. orchestrating (empty ws dir → no briefs → orchestrating) =="
-SESSION="smk-orch"
-make_fixture_copy orchestrating orchestrating-ws
-"$ACT" minimal "$SESSION" "$TMPFIX"
+S5="$(session_key orch)"
+setup_scenario orchestrating orchestrating-ws "$S5"
 
-assert_allow_cmd "git status" "git status (orchestrating)"
-assert_deny_cmd "ls" "ls (orchestrating)"
-assert_allow_write "$TMPFIX/sdd/new-ws/x.md" "write sdd_root new-ws (orchestrating)"
-assert_deny_write "$REPO/plugins/foo.txt" "write repo path (orchestrating)"
+assert_allow_cmd "$S5" "git status" "git status (orchestrating)"
+assert_deny_cmd "$S5" "ls" "ls (orchestrating)"
+assert_allow_write "$S5" "$TMPROOT/orchestrating-ws/sdd/new-ws/x.md" "write sdd_root new-ws (orchestrating)"
+assert_deny_write "$S5" "$REPO/plugins/foo.txt" "write repo path (orchestrating)"
 
-echo "OK — sdd-gate-allow-deny-smoke"
+echo "OK — sdd-gate-allow-deny-smoke ($ASSERT_COUNT assertions)"

--- a/plugins/superpowers-overrides/tests/sdd-gate-allow-deny-smoke.sh
+++ b/plugins/superpowers-overrides/tests/sdd-gate-allow-deny-smoke.sh
@@ -111,7 +111,8 @@ for needle in "SDD orchestrator gate" "Allowed Bash (read-only diagnostics):" \
               "git branch" "git remote" "git ls-files" "git diff-tree" \
               "sdd-run-task-claude.sh" "sdd-workspace / task-brief / review-package" \
               "Allowed Write:" ".superpowers/sdd/active-ws/" \
-              "--task 1 --mode implement" "See spor-SDD Rule 0a item 4."; do
+              "--task 1 --mode implement" "Full matrix: docs/sdd-h6-reference.md (SDD gate matrix)" \
+              "See spor-SDD Rule 0a item 4."; do
   r="$(bash_reason "$S1" "ls")"
   [[ "$r" == *"$needle"* ]] || fail "deny message missing: $needle"
 done

--- a/plugins/superpowers-overrides/tests/sdd-gate-allow-deny-smoke.sh
+++ b/plugins/superpowers-overrides/tests/sdd-gate-allow-deny-smoke.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# sdd-gate-allow-deny-smoke.sh — full allow/deny decision matrix smoke test.
+#
+# Covers spec §设计 判定矩阵 for the shared sdd-orchestrator-gate.sh state machine,
+# driven through the Claude PreToolUse adapter (override-claude-sdd-gate.sh):
+#   - read-only git diagnostics allow (AC1 boundary cases + `-c` v1 deny)
+#   - mutating git verbs / non-git commands deny
+#   - stub-ws (TASK_BASE: abc) does NOT activate; real-SHA active-ws does
+#   - bound-ws wins over workspace scanning (unrelated ws not activated)
+#   - deny message is the multi-line allowlist matrix (lists git show etc.)
+#   - task_complete phase re-allows shell + Write (realtime phase, no caching)
+#
+# Fixture isolation (spec §设计 fixture): each scenario is copied to a temp dir,
+# git-init'ed, and briefs carrying `TASK_BASE: <SHA>` get the copy's real short SHA
+# injected — tracked fixture files are never modified (P4 anti-pattern).
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+GATE="$ROOT/bin/override-claude-sdd-gate.sh"
+ACT="$ROOT/bin/sdd-session-activate.sh"
+FIXTURES="$ROOT/tests/fixtures/sdd-gate"
+REPO="$(git -C "$ROOT/../.." rev-parse --show-toplevel)"
+
+PENDING="${TMPDIR:-/tmp}/oscaner-superpowers-overrides/pending-sdd"
+mkdir -p "$PENDING"
+find "$PENDING" -name '*.json' -delete
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"; find "$PENDING" -name "*.json" -delete' EXIT
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+SESSION=""
+ASSERT_COUNT=0
+
+# make_fixture_copy <scenario> <dest-name> — copy a fixture scene root into
+# $TMPROOT/<dest-name>, git-init the copy, and inject the copy's real short SHA
+# into any `TASK_BASE: <SHA>` brief placeholder (stub briefs keep `abc`).
+# Exports SDD_GATE_FIXTURES_ROOT so the gate scans the copy, not the real tree.
+make_fixture_copy() {
+  local scen="$1" name="$2" sha b
+  TMPFIX="$TMPROOT/$name"
+  cp -R "$FIXTURES/$scen/." "$TMPFIX/"
+  git -C "$TMPFIX" init -q
+  git -C "$TMPFIX" add -A
+  git -C "$TMPFIX" -c user.name="sdd-gate-smoke" -c user.email="sdd-gate-smoke@example.com" \
+    commit --allow-empty -qm "fixture"
+  sha="$(git -C "$TMPFIX" rev-parse --short HEAD)"
+  while IFS= read -r b; do
+    if grep -q 'TASK_BASE: <SHA>' "$b"; then
+      printf 'TASK_BASE: %s\n' "$sha" > "$b"
+    fi
+  done < <(find "$TMPFIX" -name 'task-*-brief.md')
+  export SDD_GATE_FIXTURES_ROOT="$TMPFIX/sdd"
+}
+
+# gate_json <tool_name> <tool_input_json> — run the adapter, return full JSON.
+gate_json() {
+  local json
+  json="$(jq -nc --arg sid "$SESSION" --arg tn "$1" --argjson ti "$2" \
+    '{session_id:$sid, tool_name:$tn, tool_input:$ti}')"
+  printf '%s' "$json" | "$GATE"
+}
+
+decision() { gate_json "$1" "$2" | jq -r '.hookSpecificOutput.permissionDecision'; }
+bash_decision() { decision Bash "$(jq -nc --arg c "$1" '{command:$c}')"; }
+write_decision() { decision Write "$(jq -nc --arg p "$1" '{file_path:$p}')"; }
+bash_reason() { gate_json Bash "$(jq -nc --arg c "$1" '{command:$c}')" | jq -r '.hookSpecificOutput.permissionDecisionReason'; }
+
+assert_allow_cmd() { [[ "$(bash_decision "$1")" == allow ]] || fail "expected allow: $2"; ASSERT_COUNT=$((ASSERT_COUNT + 1)); }
+assert_deny_cmd() { [[ "$(bash_decision "$1")" == deny ]] || fail "expected deny: $2"; ASSERT_COUNT=$((ASSERT_COUNT + 1)); }
+assert_allow_write() { [[ "$(write_decision "$1")" == allow ]] || fail "expected allow: $2"; ASSERT_COUNT=$((ASSERT_COUNT + 1)); }
+assert_deny_write() { [[ "$(write_decision "$1")" == deny ]] || fail "expected deny: $2"; ASSERT_COUNT=$((ASSERT_COUNT + 1)); }
+assert_other_allow() { [[ "$(decision "$1" "$2")" == allow ]] || fail "expected allow: $3"; ASSERT_COUNT=$((ASSERT_COUNT + 1)); }
+
+assert_reason_contains() {  # <needle> <desc> — matrix text against a representative deny
+  local r
+  r="$(bash_reason "ls")"
+  [[ "$r" == *"$1"* ]] || fail "deny message missing '$1': $2"
+  ASSERT_COUNT=$((ASSERT_COUNT + 1))
+}
+
+echo "== 1. active-ws (minimal → scan → task_active) =="
+SESSION="smk-active"
+make_fixture_copy active active-ws
+"$ACT" minimal "$SESSION" "$TMPFIX"
+
+# read-only git diagnostics allow (AC1 boundary cases)
+assert_allow_cmd "git status" "git status"
+assert_allow_cmd "git -C $REPO status" "git -C <repo> status"
+assert_allow_cmd "git --git-dir=$REPO/.git status" "git --git-dir=<repo> status"
+assert_allow_cmd "git diff HEAD~1" "git diff HEAD~1"
+assert_allow_cmd "git rev-parse HEAD" "git rev-parse HEAD"
+assert_allow_cmd "git branch -a" "git branch -a"
+assert_allow_cmd "git remote -v" "git remote -v"
+assert_allow_cmd "git ls-files" "git ls-files"
+assert_allow_cmd "git diff-tree --stat HEAD" "git diff-tree"
+
+# AC1 v1 out-of-scope: `-c` config option not in extraction range → deny
+assert_deny_cmd "git -C $REPO -c k=v status" "git -C <repo> -c k=v status (v1 deny)"
+
+# mutating git verbs deny
+assert_deny_cmd "git add foo" "git add"
+assert_deny_cmd "git commit -m x" "git commit"
+assert_deny_cmd "git push origin main" "git push"
+assert_deny_cmd "git branch -d foo" "git branch -d (mutating sub-verb)"
+assert_deny_cmd "git remote add origin $REPO" "git remote add (mutating sub-verb)"
+
+# non-git commands still deny (spec Non-goals: ls/echo not in the read-only set)
+assert_deny_cmd "ls" "ls"
+assert_deny_cmd "echo hi" "echo"
+
+# allowlist Bash
+assert_allow_cmd "$ROOT/bin/sdd-run-task-claude.sh --task 1 --mode implement" "H6 sdd-run-task"
+assert_allow_cmd "sdd-workspace create x" "sdd-workspace"
+assert_allow_cmd "task-brief --task 1" "task-brief"
+assert_allow_cmd "review-package --task 1" "review-package"
+
+# Write: workspace allow, other repo paths deny
+assert_allow_write "$TMPFIX/sdd/active-ws/progress.md" "write active-ws"
+assert_deny_write "$TMPFIX/sdd/ledger.md" "write sdd_root ledger (outside active-ws)"
+assert_deny_write "$REPO/plugins/foo.txt" "write repo path (task_active)"
+
+# other tools always allow
+assert_other_allow Read '{}' "Read tool"
+
+# adapter JSON shape (hookSpecificOutput.permissionDecision / hookEventName / reason)
+out="$(gate_json Bash "$(jq -nc --arg c "ls" '{command:$c}')")"
+printf '%s' "$out" | jq -e '.hookSpecificOutput.hookEventName == "PreToolUse"' >/dev/null || fail "hookEventName != PreToolUse"
+printf '%s' "$out" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' >/dev/null || fail "shape: expected deny"
+printf '%s' "$out" | jq -e '(.hookSpecificOutput.permissionDecisionReason | length) > 0' >/dev/null || fail "empty permissionDecisionReason"
+ASSERT_COUNT=$((ASSERT_COUNT + 1))
+
+# deny message is the multi-line matrix: git show listed, H6 command, workspace scope
+for needle in "SDD orchestrator gate" "Allowed Bash (read-only diagnostics):" \
+              "git status" "git diff" "git log" "git show" "git rev-parse" \
+              "sdd-run-task-claude.sh" "Allowed Write:" ".superpowers/sdd/active-ws/" \
+              "--task 1 --mode implement"; do
+  r="$(bash_reason "ls")"
+  [[ "$r" == *"$needle"* ]] || fail "deny message missing: $needle"
+done
+ASSERT_COUNT=$((ASSERT_COUNT + 1))
+
+echo "== 2. stub-ws (TASK_BASE: abc → not a git object → orchestrating, no hijack) =="
+SESSION="smk-stub"
+make_fixture_copy stub stub-ws
+"$ACT" minimal "$SESSION" "$TMPFIX"
+
+# stub brief keeps `TASK_BASE: abc` (no <SHA> placeholder) — must NOT activate
+# (git-object validation fails). Phase stays orchestrating: read-only git +
+# sdd_root writes allow, direct repo edits deny.
+assert_allow_cmd "git status" "git status (orchestrating)"
+assert_allow_write "$TMPFIX/sdd/stub-ws/x.md" "write stub-ws (orchestrating sdd_root)"
+assert_allow_write "$TMPFIX/sdd/ledger.md" "write sdd_root ledger (orchestrating)"
+assert_deny_write "$REPO/plugins/foo.txt" "write repo path (orchestrating)"
+assert_deny_cmd "ls" "ls (orchestrating)"
+
+# plan basename falls back to unknown-plan → proves stub-ws was NOT activated
+assert_reason_contains "unknown-plan" "stub-ws hijack check (expected unknown-plan)"
+
+echo "== 3. bound-ws (bind → bound workspace wins, unrelated ws not scanned) =="
+SESSION="smk-bound"
+make_fixture_copy active bound-ws
+mkdir -p "$TMPFIX/sdd/unrelated-ws"
+printf 'TASK_BASE: %s\n' "$(git -C "$TMPFIX" rev-parse --short HEAD)" > "$TMPFIX/sdd/unrelated-ws/task-1-brief.md"
+"$ACT" bind "$SESSION" "$TMPFIX" "$TMPFIX/plan.md" "$TMPFIX/sdd/active-ws"
+
+assert_allow_write "$TMPFIX/sdd/active-ws/progress.md" "write bound active-ws"
+assert_deny_write "$TMPFIX/sdd/unrelated-ws/x.md" "write unrelated-ws (bound wins, not scanned)"
+assert_deny_write "$REPO/plugins/foo.txt" "write repo path (task_active)"
+assert_deny_cmd "git add foo" "git add (task_active)"
+assert_allow_cmd "git status" "git status (task_active)"
+
+# bound deny message resolves plan basename from plan_path (plan.md → plan)
+assert_reason_contains ".superpowers/sdd/plan/" "bound deny message should use plan_path basename"
+
+echo "== 4. complete-ws (APPROVED handoff + real SHA → task_complete → shell/Write allow) =="
+SESSION="smk-complete"
+make_fixture_copy complete complete-ws
+"$ACT" bind "$SESSION" "$TMPFIX" "$TMPFIX/plan.md" "$TMPFIX/sdd/complete-ws"
+
+# task_complete: shell and Write re-allowed (realtime phase, no caching)
+assert_allow_cmd "ls" "bash ls (task_complete)"
+assert_allow_cmd "git add foo" "bash git add (task_complete)"
+assert_allow_write "$REPO/plugins/foo.txt" "write repo path (task_complete)"
+assert_allow_write "$TMPFIX/sdd/complete-ws/x.md" "write complete-ws (task_complete)"
+
+echo "== 5. orchestrating (empty ws dir → no briefs → orchestrating) =="
+SESSION="smk-orch"
+make_fixture_copy orchestrating orchestrating-ws
+"$ACT" minimal "$SESSION" "$TMPFIX"
+
+assert_allow_cmd "git status" "git status (orchestrating)"
+assert_deny_cmd "ls" "ls (orchestrating)"
+assert_allow_write "$TMPFIX/sdd/new-ws/x.md" "write sdd_root new-ws (orchestrating)"
+assert_deny_write "$REPO/plugins/foo.txt" "write repo path (orchestrating)"
+
+echo "OK — sdd-gate-allow-deny-smoke"

--- a/plugins/superpowers-overrides/tests/sdd-gate-test-lib.sh
+++ b/plugins/superpowers-overrides/tests/sdd-gate-test-lib.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# sdd-gate-test-lib.sh — shared fixture isolation + session namespacing for the
+# SDD gate tests. Sourced by the three gate test scripts (override-claude,
+# override-cursor, allow-deny smoke); do not run standalone.
+#
+# Isolation model (spec §设计 测试 fixture 隔离): every scenario is copied from
+# tests/fixtures/sdd-gate/<scene>/ into a per-run temp dir, the copy is git-init'ed,
+# and briefs carrying the `<SHA>` placeholder get the copy's own short-SHA injected.
+# Tracked fixture files are never modified (P4 anti-pattern).
+#
+# Session keys are namespaced per-run (smk-<base>-$$) so overlapping test
+# invocations — and a live SDD session on the same machine — never share or
+# clobber each other's pending-sdd JSON in the gate's global pending root.
+
+# Caller must set ROOT before sourcing. Derive the plugin tree from $ROOT.
+TESTS_DIR="$(cd "$ROOT/tests" && pwd)"
+FIXTURES="$TESTS_DIR/fixtures/sdd-gate"
+GATE_ROOT="${SDD_PENDING_ROOT:-${TMPDIR:-/tmp}/oscaner-superpowers-overrides/pending-sdd}"
+
+SESSION_TAG="${SDD_GATE_TEST_TAG:-$$}"
+TMPROOT="$(mktemp -d)"
+
+# cleanup — remove this run's own pending-sdd JSON files. Scoped to the session
+# keys this run created; never a global find -delete (that would clobber a
+# concurrent or live session's gate, fail-open semantics violation).
+sdd_gate_test_cleanup() {
+  local key
+  rm -rf "$TMPROOT"
+  for key in "${SESSION_KEYS[@]:-}"; do
+    rm -f "$GATE_ROOT/$key.json"
+  done
+}
+trap 'sdd_gate_test_cleanup' EXIT
+
+# session_key <base> — per-run namespaced key: smk-<base>-$$. Unique to this
+# process, so overlapping runs never write the same pending file.
+session_key() {
+  printf '%s-%s-%s\n' "smk" "$1" "$SESSION_TAG"
+}
+
+# setup_scenario <scenario> <dest-name> [<session-key>] — copy a fixture scene
+# root into $TMPROOT/<dest-name>, git-init the copy, inject the copy's own short
+# SHA into any `<SHA>` brief placeholder, and export SDD_GATE_FIXTURES_ROOT so
+# the gate scans the copy instead of the real tree. With <session-key>, creates
+# the namespaced pending file via sdd-session-activate minimal mode.
+#
+# Result path is left in $SCEN_DEST. Do NOT call this inside $() — the export
+# and SESSION_KEYS bookkeeping would be lost to the subshell.
+setup_scenario() {
+  local scen="$1" name="$2" key="${3:-}" sha b
+  local dest="$TMPROOT/$name"
+  cp -R "$FIXTURES/$scen/." "$dest/"
+  git -C "$dest" init -q
+  git -C "$dest" add -A
+  git -C "$dest" -c user.name="sdd-gate-test" -c user.email="sdd-gate-test@example.com" \
+    commit --allow-empty -qm "fixture"
+  sha="$(git -C "$dest" rev-parse --short HEAD)"
+  while IFS= read -r b; do
+    if grep -q 'TASK_BASE: <SHA>' "$b"; then
+      printf 'TASK_BASE: %s\n' "$sha" > "$b"
+    fi
+  done < <(find "$dest" -name 'task-*-brief.md')
+  export SDD_GATE_FIXTURES_ROOT="$dest/sdd"
+  SCEN_DEST="$dest"
+  if [[ -n "$key" ]]; then
+    "$ACT" minimal "$key" "$dest"
+    SESSION_KEYS+=("$key")
+  fi
+}

--- a/scripts/ci-validate.sh
+++ b/scripts/ci-validate.sh
@@ -59,6 +59,7 @@ echo "== 5. overrides build validation =="
 ./plugins/superpowers-overrides/tests/sdd-cli-dry-run-smoke.sh
 ./plugins/superpowers-overrides/tests/override-cursor-sdd-gate.test.sh
 ./plugins/superpowers-overrides/tests/override-claude-sdd-gate.test.sh
+./plugins/superpowers-overrides/tests/sdd-gate-allow-deny-smoke.sh
 
 echo "== 6. marketplace validate =="
 node scripts/validate-marketplace.mjs


### PR DESCRIPTION
## Summary

Documents why SDD CLI agents (sdd-run-task-claude.sh, sdd-run-task-cursor.sh) are not visible in the /resume session list — print mode (-p/--print) is inherently non-interactive and does not register sessions in ~/.claude/sessions/.

## What changed

- **H6.6** in sdd-h6-reference.md: new rule documenting session traceability limitation, audit trail (ledger + handoff + reports), recovery procedure, and alternatives considered
- **sdd-run-task-claude.sh**: comment noting print mode session behavior
- **sdd-run-task-cursor.sh**: comment noting print mode session behavior
- **changeset**: patch bump for superpowers-overrides

## Test Plan

- pnpm run validate ALL PASS
- Verified H6.6 appears as numbered item 6 under H6 section
- Verified both shell script comments correctly reference H6.6

Closes #79